### PR TITLE
fix 'Boostrap' typos

### DIFF
--- a/Documentation/Configuration/Extension/Index.rst
+++ b/Documentation/Configuration/Extension/Index.rst
@@ -22,7 +22,7 @@ The backend skin is disabled by default if ext:themes is installed, but you can 
 
 Use RealURL Config from BootstrapPackage
 ========================================
-The Boostrap Package comes with its own RealURL configuration and will override your Configuration by default.
+The Bootstrap Package comes with its own RealURL configuration and will override your Configuration by default.
 If you want to use your own RealURL config you can disable this option.
 
 **Configuration can be found here:**

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -24,7 +24,7 @@ Bootstrap Package
         en
 
     :Description:
-        Boostrap Package delivers a full configured frontend for TYPO3 CMS 6.2, based on the Bootstrap CSS Framework.
+        Bootstrap Package delivers a full configured frontend for TYPO3 CMS 6.2, based on the Bootstrap CSS Framework.
 
     :Keywords:
         Theme,Bootstrap

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -10,7 +10,7 @@
 Introduction
 ==============================
 
-The Boostrap Package is a Theme for TYPO3 CMS based on the `Bootstrap CSS Framework <http://getbootstrap.com/>`_ Version 3.2.0
+The Bootstrap Package is a Theme for TYPO3 CMS based on the `Bootstrap CSS Framework <http://getbootstrap.com/>`_ Version 3.2.0
 
 Features
 ==============================

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,7 +6,7 @@
 
 $EM_CONF[$_EXTKEY] = array (
     'title' => 'Bootstrap Package',
-    'description' => 'Boostrap Package delivers a full configured frontend for TYPO3 CMS 6.2, based on the Bootstrap CSS Framework.',
+    'description' => 'Bootstrap Package delivers a full configured frontend for TYPO3 CMS 6.2, based on the Bootstrap CSS Framework.',
     'category' => 'templates',
     'shy' => 0,
     'version' => '6.2.6-dev',


### PR DESCRIPTION
Your GitHub repo's description field also has this same typo in it.
