### PR TITLE
Move img class to params for easier customization.

### DIFF
--- a/Configuration/ContentElements/Base.ts
+++ b/Configuration/ContentElements/Base.ts
@@ -6,7 +6,7 @@ tt_content.image.20.1 {
     layout {
         bootstrappackage {
             element (
-                <img src="typo3conf/ext/bootstrap_package/Resources/Public/Images/blank.gif" ###SOURCECOLLECTION######PARAMS######ALTPARAMS######SELFCLOSINGTAGSLASH###>
+                <img src="typo3conf/ext/bootstrap_package/Resources/Public/Images/blank.gif" ###PARAMS######SOURCECOLLECTION######ALTPARAMS######SELFCLOSINGTAGSLASH###>
                 <noscript>
                     <img src="###SRC###" />
                 </noscript>


### PR DESCRIPTION
It's easier to customize the class of images if we use params, else a complete rewrite of bootstrappackage element is needed. It shouldn't break anything.
Please pull this if you find it good :)
