### PR TITLE
No top margin for the first text header of the page.

### DIFF
--- a/Resources/Private/Less/Theme/text.less
+++ b/Resources/Private/Less/Theme/text.less
@@ -18,7 +18,9 @@ h4,
 h5 {
     font-family: @font-family-base;
 }
-
+.csc-firstHeader {
+	margin-top: 0;
+}
 
 //
 // Body text


### PR DESCRIPTION
Hi @benjaminkott,
I suggest to add this CSS rule:
`.csc-firstHeader { margin-top: 0; }`

So the first text header of the page doesn't have too much space from the header/breadcrumb and also it aligns vertically with the eventual left/right sided secondary menu.
