### PR TITLE
Makes Carousel item header not required.

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -275,7 +275,7 @@ return array(
             'config' => array(
                 'type' => 'input',
                 'size' => 50,
-                'eval' => 'trim,required'
+                'eval' => 'trim'
             ),
         ),
         'bodytext' => array(

--- a/Resources/Private/Partials/ContentElements/Carousel/Item/Header.html
+++ b/Resources/Private/Partials/ContentElements/Carousel/Item/Header.html
@@ -1,3 +1,4 @@
+<f:if condition="{item.header}">
 <div class="valign" {f:if(condition: item.text_color,then:'style="color: {item.text_color};"')}>
      <div class="vcontainer">
          <div class="carousel-text-inner">
@@ -5,3 +6,4 @@
          </div>
     </div>
 </div>
+</f:if>


### PR DESCRIPTION
This way the Carousel can be used as a simple image gallery with no text over.
