### PR TITLE
Lead text in RTE is not saved

### DIFF
--- a/Configuration/PageTS/RTE.txt
+++ b/Configuration/PageTS/RTE.txt
@@ -248,7 +248,7 @@ RTE.default.proc {
     // List of allowed classes in the RTE
     allowedClasses (
         table, table-striped, table-bordered, table-hover, table-condensed,
-        text-left, text-center, text-right, text-justify,
+        text-left, text-center, text-right, text-justify, lead,
         active, success, warning, danger, info,
         list-unstyled, list-inline,
         btn, btn-default, btn-primary, btn-success, btn-warning, btn-block,


### PR DESCRIPTION
Hi @benjaminkott,
editors are no more able to save a text with class="lead" cause it's no more in RTE allowed classes.
This fixes the RTE configuration.
