### PR TITLE
[BUGFIX] Make getCompiledFile a static method

### DIFF
--- a/Classes/Service/CompileService.php
+++ b/Classes/Service/CompileService.php
@@ -37,7 +37,7 @@ class CompileService {
     /**
      * @param string $file
      */
-    public function getCompiledFile($file) {
+    public static function getCompiledFile($file) {
         $file = GeneralUtility::getFileAbsFileName($file);
         $pathParts = pathinfo($file);
         if($pathParts['extension'] === 'less'){


### PR DESCRIPTION
TYPO3 sets the deprecation strategy to the strictest possible when in Development mode.
That includes hard Exceptions on PHP 5.6.

This patch makes the method static which shouldnt harm anyone.
