### PR TITLE
[TASK] Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+charset = utf-8
+
+# Get rid of whitespace to avoid diffs with a bunch of EOL changes
+trim_trailing_whitespace = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# CSS-Files
+[*.css]
+indent_style = tab
+indent_size = 4
+
+# HTML-Files
+[*.html]
+indent_style = tab
+indent_size = 4
+
+# TMPL-Files
+[*.tmpl]
+indent_style = tab
+indent_size = 4
+
+# LESS-Files
+[*.less]
+indent_style = tab
+indent_size = 4
+
+# JS-Files
+[*.js]
+indent_style = tab
+indent_size = 4
+
+# PHP-Files
+[*.php]
+indent_style = tab
+indent_size = 4
+
+# MD-Files
+[*.md]
+indent_style = space
+indent_size = 4
+
+# package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This adds the .editorconfig file from TYPO3 Core to make contributions easier in the sense that the IDE will apply the formatting rules automatically.

Especially useful if you're working on multiple projects with multiple coding styles
