### PR TITLE
Update jquery.responsiveimages.js

### DIFF
--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -17,7 +17,9 @@
 					720: 'medium',
 					940: 'large',
 					1140: 'bigger'
-				}
+				},
+				container:window,
+                                skip_invisible: true
 			},
 			options = $.extend({}, defaults, options),
 			$window = $(window),
@@ -51,24 +53,40 @@
 			}
 			responsiveimages();
 		}
-
+		function inviewport($el, options){
+        		var $c = $(options.container)    
+        		,   ew = $el.width()
+        		,   eh = $el.height()
+        		,   el = $el.offset().left    
+        		,   et = $el.offset().top    
+        		,   cw = $c.width()   
+        		,   ch    
+        		,   cl  
+        		,   ct;
+          		if (options.container === undefined || options.container === window){
+            			ch = window.innerHeight ? window.innerHeight : $window.height();
+            			cl = $window.scrollLeft();
+            			ct = $window.scrollTop();
+          		} else {
+            			ch = $c.height();
+            			cl = $c.offset().left;
+            			ct = $c.offset().top;
+          		}
+          		return cl + cw > el - options.threshold && cl < el + ew + options.threshold && ct + ch > et - options.threshold && ct < et + eh + options.threshold   
+        	}
 		function responsiveimages() {
 			var inview = images.filter(function () {
 				var $element = $(this);
-				if ($element.is(":hidden")) return;
-				var wt = $(window).scrollTop(),
-					wb = wt + $(window).height(),
-					et = $element.offset().top,
-					eb = et + $element.height();
-				return eb >= wt - threshold && et <= wb + threshold;
+				if (options.skip_invisible && $element.is(":hidden")) return;
+				return inviewport($element, options);  
 			});
 			loaded = inview.trigger("responsiveimages");
 			images = images.not(loaded);
 		}
 
-		$window.scroll(checkviewport);
+		$(options.container).scroll(checkviewport);
 		$window.resize(checkviewport);
-
+ 		$.fn.responsiveimages.update = checkviewport;
 		checkviewport();
 
 		return this;


### PR DESCRIPTION
Add options for container and skip_invisible
according : http://www.appelsiini.net/projects/lazyload
Webkit browsers will report images without width and height as not .not(":visible"). This causes images to appear only when you scroll a bit. Either fix your image tags or set skip_invisible to false.

Better handling of top/bottom left/right position of element
inspired by http://www.appelsiini.net/projects/lazyload
to allow onepage horizontal layouts with jquery.ascensor.js
http://kirkas.ch/ascensor/#Home

Allow external call to $.fn.responsiveimages.update()
eg on ascensor page transition
