### PR TITLE
Don't overwrite existing configuration completely

### DIFF
--- a/Configuration/RealURL/Default.php
+++ b/Configuration/RealURL/Default.php
@@ -1,38 +1,49 @@
 <?php
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['init']['enableCHashCache'] = TRUE;
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['init']['appendMissingSlash'] = 'ifNotFile';
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['init']['enableUrlDecodeCache'] = TRUE;
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['init']['enableUrlEncodeCache'] = TRUE;
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['init']['emptyUrlReturnValue'] = \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL');
-
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['type'] = 'user';
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['userFunc'] = 'EXT:realurl/class.tx_realurl_advanced.php:&tx_realurl_advanced->main';
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['spaceCharacter'] = '-';
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['languageGetVar'] = 'L';
-
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['preVars'] = array(
-	'0' => array(
-			'GETvar' => 'no_cache',
-			'valueMap' => array(
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'] = array_merge_recursive(
+	$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT'],
+	array(
+		'init' => array(
+			'enableCHashCache' => TRUE,
+			'appendMissingSlash' => 'ifNotFile',
+			'enableUrlDecodeCache' => TRUE,
+			'enableUrlEncodeCache' => TRUE,
+			'emptyUrlReturnValue' => \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL'),
+		),
+		'pagePath' => array(
+			'type' => 'user',
+			'userFunc' => 'EXT:realurl/class.tx_realurl_advanced.php:&tx_realurl_advanced->main',
+			'spaceCharacter' => '-',
+			'languageGetVar' => 'L',
+		),
+		'preVars' => array(
+			'0' => array(
+				'GETvar' => 'no_cache',
+				'valueMap' => array(
 					'nc' => '1',
+				),
+				'noMatch' => 'bypass'
 			),
-			'noMatch' => 'bypass'
-	),
-	'1' => array(
-			'GETvar' => 'L',
-			'valueMap' => array(
+			'1' => array(
+				'GETvar' => 'L',
+				'valueMap' => array(
 					'da' => '1',
 					'de' => '2',
-			),
-			'noMatch' => 'bypass',
-	),
+				),
+				'noMatch' => 'bypass',
+			)
+		),
+		'postVarSets' => array(
+			'_DEFAULT' => array(
+				'page' => array(
+					0 => array(
+						'GETvar' => 'page',
+					)
+				)
+			)
+		),
+		'fileName' => array(
+			'defaultToHTMLsuffixOnPrev' => TRUE
+		)
+	)
 );
-
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['postVarSets']['_DEFAULT']['page'] = array(
-	0 => array(
-			'GETvar' => 'page',
-	),
-);
-
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['fileName']['defaultToHTMLsuffixOnPrev'] = TRUE;


### PR DESCRIPTION
Only set the required RealURL configuration for the bootstrap package and leave existing configurations from other extensions as is to allow them defining own rules for their urls.
