### PR TITLE
[BUGFIX] Typoscript languagemenu fix language stdwrap

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -33,7 +33,7 @@ lib.language {
 			NO = 1
 			NO {
 				linkWrap = <li>|</li>
-				stdWrap.override = English || Dansk || Deutsch
+				stdWrap.override = English || Deutsch || Dansk
 				doNotLinkIt = 1
 				stdWrap {
 					typolink {


### PR DESCRIPTION
The language menu shows now the correct name for the uid. (uid 1 =
Deutsch and uid 2 = Dansk)