### PR TITLE
Fix deprecation of page.includeJSlibs

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -416,7 +416,7 @@ page {
 		theme = EXT:bootstrap_package/Resources/Private/Less/Theme/theme.less
 	}
 
-	includeJSlibs {
+	includeJSLibs {
 		modernizr = {$page.includePath.javascript}Libs/modernizr-2.8.3.min.js
 		modernizr.forceOnTop = 1
 		wpfix = {$page.includePath.javascript}Libs/windowsphone-viewportfix.min.js


### PR DESCRIPTION
Fix deprecation message:
The property page.includeJSlibs is marked for deprecation and will be removed in TYPO3 CMS 8. Please use page.includeJSLibs (with a uppercase L) instead.