### PR TITLE
Responsive images

### DIFF
--- a/Configuration/ContentElements/Base.ts
+++ b/Configuration/ContentElements/Base.ts
@@ -1,50 +1,233 @@
 ###########################
 #### RESPONSIVE IMAGES ####
 ###########################
-tt_content.image.20.1 {
-	layout {
-		bootstrappackage {
-			element (
-				<img src="typo3conf/ext/bootstrap_package/Resources/Public/Images/blank.gif" ###PARAMS######SOURCECOLLECTION######ALTPARAMS######SELFCLOSINGTAGSLASH###>
-				<noscript>
-					<img src="###SRC###"###ALTPARAMS###/>
-				</noscript>
-			)
-			source = data-###DATAKEY###="###SRC###"
-			source.noTrimWrap = ; ;;
-			source.noTrimWrap.splitChar = ;
-		}
-	}
 
-	sourceCollection >
-	sourceCollection {
-		src {
-			dataKey = src
-		}
-
-		bigger {
-			width = 1140
-			dataKey = bigger
-		}
-
-		large {
-			width = 940
-			dataKey = large
-		}
-
-		medium {
-			width = 720
-			dataKey = medium
-		}
-
-		small {
-			width = 320
-			dataKey = small
-		}
-	}
-
-	params = class="lazyload"
+## compute image width for each srcset
+lib.responsiveWidth = COA 
+lib.responsiveWidth {
+  5 = TEXT
+  5.value = ((
+  
+  ## avaliable width
+  10 = TEXT
+  10 {
+    value = {register:width_lg}
+    insertData = 1
+    
+    # handle available width for image above text 
+    stdWrap  {
+      
+      wrap {
+        cObject = TEXT
+        cObject {
+          value = (|-{$plugin.lef_bootstrap3_package.gutter})/2
+          stdWrap.if {
+            value = 10 
+            isGreaterThan.field = imageorient 
+          }
+        }
+      }
+      
+      outerWrap = (|)  
+    }
+    
+  }
+  
+  
+  ## handle multi columns layouts
+  20 = COA
+  20 {
+    
+    ## remove gutter width
+    10 = TEXT
+    10.value = {$plugin.lef_bootstrap3_package.gutter}
+    
+    15 = TEXT
+    15.value = +(
+    
+    ## handle gutters between multiple columns 
+    20 = TEXT
+    20.value = {$styles.content.imgtext.colSpace}
+      
+    25 = TEXT
+    25.value =  *
+    
+    30 = TEXT
+    30{
+      value = ({field:imagecols}-1)
+      insertData = 1 
+    }
+    
+    35 = TEXT
+    35.value = )
+    stdWrap.wrap = -(|)  
+  }
+  
+  30 = TEXT
+  30.value = )
+  
+  # handle columns width for multicolumn width  
+  40 = TEXT
+  40 {
+    # divide by the number of columns
+    value = /{field:imagecols}
+    insertData = 1
+    
+  }
+  
+  50 = TEXT 
+  50.value = )
+  
+  # handle border thick and space
+  60 = TEXT
+  60 {
+    value = -(({$styles.content.imgtext.borderThick}+{$styles.content.imgtext.borderSpace})*2)
+    stdWrap.if.isTrue.field = imageborder
+  }
 }
+
+## overrides layout and sourceCollection
+tt_content.image.20.1 {
+  
+  layout {
+    ### remove width and height attrib from image
+    default.element = <img src="###SRC###" ###PARAMS######ALTPARAMS######BORDER######SELFCLOSINGTAGSLASH###>  
+    bootstrappackage{
+      element (
+      <img src="typo3conf/ext/bootstrap_package/Resources/Public/Images/blank.gif" ###SOURCECOLLECTION######PARAMS######ALTPARAMS######SELFCLOSINGTAGSLASH###>
+      <noscript>
+      <img src="###SRC###" ###ALTPARAMS###/>
+      </noscript>
+      )
+      source = data-###DATAKEY###="###SRC###" 
+      source.noTrimWrap = ; ;;
+      source.noTrimWrap.splitChar = ;
+    }
+  }
+  
+  layoutKey = bootstrappackage
+  
+    sourceCollection >
+    sourceCollection {
+    src{
+      dataKey = src
+    }
+    bigger < .src
+    
+    bigger{ 
+      width.stdWrap{
+        cObject  < lib.responsiveWidth
+        cObject.10.value = {register:width_lg}
+        prioriCalc = intval
+      }
+      
+      maxW = < .width
+      pixelDensity = 1
+      dataKey = bigger
+      
+    }
+    
+    large < .bigger
+    large{  
+      width.stdWrap.cObject.10.value = {register:width_md}
+      maxW = < .width
+      dataKey = large
+    }
+    medium < .bigger
+    medium { 
+      width.stdWrap.cObject{
+        10.value = {register:width_sm}
+        # width of images in columns depends on breakpoints and number of columns
+        20{
+          30 >
+          30 = CASE
+          30{
+            key.field = imagecols
+            
+            default = TEXT
+            default.value = 1
+            2 < .default
+            3 < .default
+            3.value = 3
+            4 < .default
+            4.value = 4
+            6 < .default
+            6.value = 6
+            stdWrap.wrap = (|-1)
+          }
+        } 
+        40 >
+        40 < .20.30
+        40.stdWrap.wrap = /|
+      }
+      
+      maxW = < .width
+      maxWInText = < .width
+      dataKey = medium
+    }
+    small < .medium
+    small {  
+      width.stdWrap.cObject{
+        10{
+          value = {register:width_xs}
+          # clear width override as text beside image dosen t make sense for sutch small device
+          # you have to ensure that css .image-wrap max-width:50% donsen t apply 
+          stdWrap >
+        }
+        # width of images in columns depends on breakpoints and number of columns
+        20{
+          30{
+            4 < .default
+            4.value = 2
+            6 < .default
+            6.value = 3
+          }
+        }
+        40 < .20.30
+        40.stdWrap.wrap = /|
+        
+      }
+      maxW = < .width
+      dataKey = small
+    }
+    ## retina
+    retina-bigger  < .bigger
+    retina-bigger{
+      if.isTrue = {$plugin.lef_bootstrap3_package.retina} 
+      pixelDensity = 2
+      dataKey =  retina-bigger
+    }
+    retina-large < .large
+    retina-large{
+      if.isTrue = {$plugin.lef_bootstrap3_package.retina}
+      pixelDensity = 2
+      dataKey =  retina-large
+    }
+    retina-medium < .medium
+    retina-medium{
+      if.isTrue = {$plugin.lef_bootstrap3_package.retina}
+      pixelDensity = 2
+      dataKey =  retina-medium
+    }
+    retina-small < .small
+    retina-small {
+      if.isTrue = {$plugin.lef_bootstrap3_package.retina}
+      pixelDensity = 2
+      dataKey =  retina-small
+    }
+  }
+  
+  params = class="lazyload"
+  params{
+    # Add a class to preload image on page load for hidden items like in tabs
+    override = class="lazyload preload"
+    override.if {   
+      equals.field = layout
+      value = 2
+    }
+  }
+}
+
 
 #################
 #### CONTENT ####
@@ -102,6 +285,54 @@ lib.dynamicContent {
 	20.select.where.insertData = 1
 	20.select.pidInList.data = register:pageUid
 	90 = RESTORE_REGISTER
+}
+
+### initial values for number of columns and layout width
+### setup column width in fluid templates
+### <f:cObject typoscriptObjectPath="lib.dymanicContent" data="{col_md: '9', col_lg: '9'}" />
+
+lib.dynamicContent.5 {
+  
+    columns_xs {
+    cObject = TEXT
+    cObject.value = {$plugin.lef_bootstrap3_package.columns}
+  }
+    columns_sm < .columns_xs
+    columns_md < .columns_xs
+    columns_lg < .columns_xs
+  
+    width_xs {
+    cObject = COA
+    cObject{
+      5 = TEXT
+      5.value = (
+      10 = TEXT
+      10.value = {$plugin.lef_bootstrap3_package.width_xs}
+      20 = TEXT
+      20.value = +{$plugin.lef_bootstrap3_package.gutter})/{$plugin.lef_bootstrap3_package.columns}* 
+      30 = TEXT
+      30 {
+        field = col_xs
+        ifEmpty =  {$plugin.lef_bootstrap3_package.columns}
+      }
+    }   
+    prioriCalc = 1
+  }
+    width_sm < .width_xs 
+    width_sm.cObject {
+    10.value = {$plugin.lef_bootstrap3_package.width_sm}
+    30.field = col_sm
+  }
+    width_md < .width_xs
+    width_md.cObject {
+    10.value = {$plugin.lef_bootstrap3_package.width_md}
+    30.field = col_md
+  }    
+    width_lg < .width_xs
+    width_lg.cObject {
+    10.value = {$plugin.lef_bootstrap3_package.width_lg}
+    30.field = col_lg
+  }
 }
 
 lib.dynamicContentSlide =< lib.dynamicContent

--- a/Configuration/PageTS/TCEFORM.txt
+++ b/Configuration/PageTS/TCEFORM.txt
@@ -19,6 +19,22 @@ TCEFORM {
 			removeItems = 1,2,3
 			disableNoMatchingValueElement = 1
 			types {
+			    image {
+      			removeItems = 3
+      			altLabels {
+        			0 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.default
+			        1 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.lazyload
+			        2 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.normal
+			      }
+			    }
+			    textpic {
+			      removeItems = 3
+			      altLabels {
+			        0 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.default
+			        1 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.lazyload
+			        2 = LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:imagelayout.normal
+			      }
+			    }
 				bullets {
 					removeItems = 0,1,2,3
 					addItems {

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -10,6 +10,11 @@
 # customsubcategory=160=Theme
 # customsubcategory=170=News
 # customsubcategory=180=Tracking
+# customsubcategory=500=Breakpoints (screen    width)
+# customsubcategory=510=Image width (container width)
+# customsubcategory=520=Columns
+# customsubcategory=530=Sizes
+# customsubcategory=540=Features
 
 ############
 ### PAGE ###
@@ -134,8 +139,11 @@ config {
 styles {
 	content {
 		imgtext {
-			maxW = 1140
-			colSpace = 30
+		  	borderThick = 1
+		  	borderSpace = 4
+		  	colSpace = 30
+		  	maxWInText = 0
+		  	maxW = 0
 			layoutKey = bootstrappackage
 		}
 	}
@@ -154,6 +162,35 @@ plugin.bootstrap_package_contentelements {
 		templateRootPath = EXT:bootstrap_package/Resources/Private/Templates/ContentElements/
 	}
 }
+
+##################################
+#### BOOTSTRAP GRID CONSTANTS ####
+##################################
+plugin.lef_bootstrap3_package {
+  # cat=responsive grid and images/500/110; type=int+; label=Breakpoint large:Width of the breakpoint large (according bootstrap)
+  breakpoint_lg = 1200
+  # cat=responsive grid and images/500/111; type=int+; label=Breakpoint medium:Width of the breakpoint medium (according bootstrap)
+  breakpoint_md = 992
+  # cat=responsive grid and images/500/112; type=int+; label=Breakpoint small:Width of the breakpoint small (according bootstrap)
+  breakpoint_sm = 768
+  # cat=responsive grid and images/500/113; type=int+; label=Breakpoint xtra small:Width of the breakpoint xtra small : layout change (according bootstrap)
+  breakpoint_xs = 480
+  # cat=responsive grid and images/510/115; type=int+; label=Container large:Width of the container large : base for images size (according bootstrap)
+  width_lg = 1140
+  # cat=responsive grid and images/510/116; type=int+; label=Container medium:Width of the container medium : base for images size (according bootstrap)
+  width_md = 940
+  # cat=responsive grid and images/510/117; type=int+; label=Container small:Width of the container small : base for images size (according bootstrap)
+  width_sm = 720
+  # cat=responsive grid and images/510/118; type=int+; label=Container xtra small:Width of the container xtra small : base for images size (according bootstrap)
+  width_xs = 420
+  # cat=responsive grid and images/520/130; type=int+; label=Number of columns:Maximum number of columns (according bootstrap)
+  columns = 12
+  # cat=responsive grid and images/530/131; type=int+; label=Gutter width:Width of the gutter (according bootstrap)
+  gutter = 30
+  # cat=responsive grid and images/540/140; type=boolean; label=Enable retina:Enable retina images in source sets
+  retina = 1
+
+  }
 
 ##################################
 #### BOOTSTRAP LESS CONSTANTS ####

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -4,7 +4,16 @@
 		  product-name="bootstrap_package">
 		<header/>
 		<body>
-
+           <trans-unit id="imagelayout.default"> 
+                <source>Default (lazyload)</source>
+            </trans-unit>
+            <trans-unit id="imagelayout.lazyload">
+                <source>Lazyload</source>
+            </trans-unit>
+            <trans-unit id="imagelayout.normal">
+                <source>Preload</source>
+            </trans-unit>
+            
 			<trans-unit id="theme_name">
 				<source>Bootstrap</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Page/Default2Columns.html
+++ b/Resources/Private/Templates/Page/Default2Columns.html
@@ -4,10 +4,10 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'9', col_lg:'9'}"/>
 			</div>
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', col_md:'3', col_lg:'3'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/Default2Columns2575.html
+++ b/Resources/Private/Templates/Page/Default2Columns2575.html
@@ -4,10 +4,10 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1'}" />
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', col_md:'3', col_lg:'3'}" />
 			</div>
 			<div class="col-md-9" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}" />
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'9', col_lg:'9'}" />
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/Default2Columns5050.html
+++ b/Resources/Private/Templates/Page/Default2Columns5050.html
@@ -4,10 +4,10 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'6', col_lg:'6'}"/>
 			</div>
 			<div class="col-md-6">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', col_md:'6', col_lg:'6'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/Default2ColumnsOffsetRight.html
+++ b/Resources/Private/Templates/Page/Default2ColumnsOffsetRight.html
@@ -4,10 +4,10 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-8" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'8', col_lg:'8'}"/>
 			</div>
 			<div class="col-md-offset-1 col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', col_md:'3', col_lg:'3'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/Default3Columns.html
+++ b/Resources/Private/Templates/Page/Default3Columns.html
@@ -4,13 +4,13 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', col_md:'3', col_lg:'3'}"/>
 			</div>
 			<div class="col-md-6" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'6', col_lg:'6'}"/>
 			</div>
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', col_md:'3', col_lg:'3'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/DefaultSubNavLeft.html
+++ b/Resources/Private/Templates/Page/DefaultSubNavLeft.html
@@ -7,7 +7,7 @@
 				<f:cObject typoscriptObjectPath="lib.navigation.subnavigation"/>
 			</div>
 			<div class="col-md-9" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'9', col_lg:'9'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/DefaultSubNavLeft2Columns.html
+++ b/Resources/Private/Templates/Page/DefaultSubNavLeft2Columns.html
@@ -7,10 +7,10 @@
 				<f:cObject typoscriptObjectPath="lib.navigation.subnavigation"/>
 			</div>
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', col_md:'3', col_lg:'3'}"/>
 			</div>
 			<div class="col-md-6" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'6', col_lg:'6'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/DefaultSubNavRight.html
+++ b/Resources/Private/Templates/Page/DefaultSubNavRight.html
@@ -4,7 +4,7 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-9" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'9', col_lg:'9'}"/>
 			</div>
 			<div class="col-md-3">
 				<f:cObject typoscriptObjectPath="lib.navigation.subnavigation"/>

--- a/Resources/Private/Templates/Page/DefaultSubNavRight2Columns.html
+++ b/Resources/Private/Templates/Page/DefaultSubNavRight2Columns.html
@@ -4,10 +4,10 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-6" role="main">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', col_md:'6', col_lg:'6'}"/>
 			</div>
 			<div class="col-md-3">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', col_md:'3', col_lg:'3'}"/>
 			</div>
 			<div class="col-md-3">
 				<f:cObject typoscriptObjectPath="lib.navigation.subnavigation"/>

--- a/Resources/Private/Templates/Page/SpecialFeature.html
+++ b/Resources/Private/Templates/Page/SpecialFeature.html
@@ -10,18 +10,18 @@
 		<div class="container">
 			<div class="row">
 				<div class="col-sm-6">
-					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '30'}"/>
+					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '30', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 				</div>
 				<div class="col-sm-6">
-					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '31'}"/>
+					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '31', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 				</div>
 			</div>
 			<div class="row">
 				<div class="col-sm-6">
-					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '32'}"/>
+					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '32', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 				</div>
 				<div class="col-sm-6">
-					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '33'}"/>
+					<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '33', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 				</div>
 			</div>
 		</div>
@@ -31,18 +31,18 @@
 		<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '4'}"/>
 		<div class="row">
 			<div class="col-sm-6">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '34'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '34', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 			</div>
 			<div class="col-sm-6">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '35'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '35', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 			</div>
 		</div>
 		<div class="row">
 			<div class="col-sm-6">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '36'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '36', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 			</div>
 			<div class="col-sm-6">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '37'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '37', col_sm:'6', col_md:'6', col_lg:'6'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Private/Templates/Page/SpecialStart.html
+++ b/Resources/Private/Templates/Page/SpecialStart.html
@@ -5,13 +5,13 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-sm-4">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '20'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '20', col_sm:'4', col_md:'4', col_lg:'4'}"/>
 			</div>
 			<div class="col-sm-4">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '21'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '21', col_sm:'4', col_md:'4', col_lg:'4'}"/>
 			</div>
 			<div class="col-sm-4">
-				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '22'}"/>
+				<f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '22', col_sm:'4', col_md:'4', col_lg:'4'}"/>
 			</div>
 		</div>
 	</div>

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -3,94 +3,144 @@
  * http://luis-almeida.github.com/unveil
  */
 
-;
-(function ($) {
+;(function($) {
+  
+    // RESPONSIVEIMAGES PLUGIN DEFINITION
+    // =================================
+    $.fn.responsiveimages = function (options,callback) {
+      // The rule is :
+      // if the layout is responsive 
+      // the value is the entry point of the breakpoint
+      
+        var defaults = {
+                threshold: 0,
+                breakpoints: {
+                    0: 'small',
+                    480: 'medium',
+                    992: 'large',
+                    1200: 'bigger'
+                },
+                container:window,
+                skip_invisible: false,
+                retina: true,
+                preloadClass:"preload"
+            },
+            options = $.extend({}, defaults, options),
+            $window = $(window),
+            threshold = options.threshold || 0,
+            breakpoints = options.breakpoints,
+            retina = options.retina && window.devicePixelRatio > 1,
+            attrib = "data-src",
+            images = this,
+            originimages = this,
+            loaded,
+            smallest_breakpoint = 1e16;
+      
+      function findSmallestBreakpoint(){
+        var bp = 0;
+        $.each(breakpoints, function(breakpoint,datakey) {
+            bp = parseInt(breakpoint);
+            if(bp < smallest_breakpoint){
+                    smallest_breakpoint = bp;
+                }
+        });  
+      }
+      
+      function getDataKey(){
+        var datakey = "src",
+            bw = bp = 0,
+            ww = $window.width();
+        
+        // window width < smallest_breakpoint
+        if (ww < smallest_breakpoint){
+          return breakpoints[smallest_breakpoint];
+          };
+        
+        // find largest breakpoint < window 
+        $.each(breakpoints, function(breakpoint,dk) {
+            bp = parseInt(breakpoint);
+            if(bp <= ww && bp > bw ){
+              bw = bp;
+              datakey = dk;
+            }
+          });
+        return datakey;
+      }
+ 
+        this.on("responsiveimages", function() {
+            var source  = this.getAttribute(attrib);
+            // fallback to non retina or src when not found
+            source = source || (retina ? this.getAttribute("data-"+getDataKey()) : false) || this.getAttribute("data-src");
+            if(source){
+                this.setAttribute("src", source);
+                if(typeof callback === "function") callback.call(this);
+            }
+        });
 
-	// RESPONSIVEIMAGES PLUGIN DEFINITION
-	// =================================
-	$.fn.responsiveimages = function (options, callback) {
+        function checkviewport(){
+            old_attrib = attrib;
+            var datakey = getDataKey();
+            attrib = (retina ? "data-retina-" : "data-") + datakey;
+            if(old_attrib != attrib){
+                images = originimages;
+            }
+            responsiveimages();
+        }
+      
+        // better handling of top/bottom left/right position of element
+        // inspired by http://www.appelsiini.net/projects/lazyload
+        // to allow onepage horizontal layouts with jquery.ascensor.js
+        // http://kirkas.ch/ascensor/#Home
+        function inviewport($el, options){
+          // preload image even when not inviewport
+          if (options.preloadClass && $el.hasClass(options.preloadClass)) return true;
+          
+          var $c = $(options.container)    
+          ,   ew = $el.width()
+          ,   eh = $el.height()
+          ,   el = $el.offset().left    
+          ,   et = $el.offset().top    
+          ,   cw = $c.width()   
+          ,   ch    
+          ,   cl  
+          ,   ct;
+          if (options.container === undefined || options.container === window){
+            ch = window.innerHeight ? window.innerHeight : $window.height();
+            cl = $window.scrollLeft();
+            ct = $window.scrollTop();
+          } else {
+            ch = $c.height();
+            cl = $c.offset().left;
+            ct = $c.offset().top;
+          }
+          //     right                                left                                 bottom                               top
+          return cl + cw > el - threshold && cl < el + ew + threshold && ct + ch > et - threshold && ct < et + eh + threshold   
+        }
+      
+        function responsiveimages() {            
+            var inview = images.filter(function() {
+              var $element = $(this);
+              if (options.skip_invisible && $element.is(":hidden")) return;
+              return inviewport($element, options);  
+            });
+            loaded = inview.trigger("responsiveimages");
+            images = images.not(loaded);
+        }
+        // use throttle plugin when present, otherwise this paceholder 
+        if ($.throttle === undefined){$.throttle = function(delay, fun){return fun;};}; 
+        $(options.container).scroll($.throttle(250,checkviewport));
+   
+        $window.resize(checkviewport);
+        
+        // allow external call to $.fn.responsiveimages.update()
+        // eg on ascensor page transition
+        $.fn.responsiveimages.update = checkviewport;
+        
+        findSmallestBreakpoint();
+        checkviewport();
+       
+        return this;
 
-		var defaults = {
-				threshold: 0,
-				breakpoints: {
-					320: 'small',
-					720: 'medium',
-					940: 'large',
-					1140: 'bigger'
-				},
-				container:window,
-                                skip_invisible: true
-			},
-			options = $.extend({}, defaults, options),
-			$window = $(window),
-			threshold = options.threshold || 0,
-			breakpoints = options.breakpoints,
-			hdpi = window.devicePixelRatio > 1,
-			attrib = "data-src",
-			images = this,
-			originimages = this,
-			loaded;
-
-		this.on("responsiveimages", function () {
-			var source = this.getAttribute(attrib);
-			source = source || this.getAttribute("data-src");
-			if (source) {
-				this.setAttribute("src", source);
-				if (typeof callback === "function") callback.call(this);
-			}
-		});
-
-		function checkviewport() {
-			old_attrib = attrib;
-			var ww = $window.width();
-			$.each(breakpoints, function (breakpoint, datakey) {
-				if (ww >= breakpoint) {
-					attrib = "data-" + datakey;
-				}
-			});
-			if (old_attrib != attrib) {
-				images = originimages;
-			}
-			responsiveimages();
-		}
-		function inviewport($el, options){
-        		var $c = $(options.container)    
-        		,   ew = $el.width()
-        		,   eh = $el.height()
-        		,   el = $el.offset().left    
-        		,   et = $el.offset().top    
-        		,   cw = $c.width()   
-        		,   ch    
-        		,   cl  
-        		,   ct;
-          		if (options.container === undefined || options.container === window){
-            			ch = window.innerHeight ? window.innerHeight : $window.height();
-            			cl = $window.scrollLeft();
-            			ct = $window.scrollTop();
-          		} else {
-            			ch = $c.height();
-            			cl = $c.offset().left;
-            			ct = $c.offset().top;
-          		}
-          		return cl + cw > el - options.threshold && cl < el + ew + options.threshold && ct + ch > et - options.threshold && ct < et + eh + options.threshold   
-        	}
-		function responsiveimages() {
-			var inview = images.filter(function () {
-				var $element = $(this);
-				if (options.skip_invisible && $element.is(":hidden")) return;
-				return inviewport($element, options);  
-			});
-			loaded = inview.trigger("responsiveimages");
-			images = images.not(loaded);
-		}
-
-		$(options.container).scroll(checkviewport);
-		$window.resize(checkviewport);
- 		$.fn.responsiveimages.update = checkviewport;
-		checkviewport();
-
-		return this;
-
-	}
+    }
 
 })(window.jQuery);

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.min.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.min.js
@@ -1,31 +1,89 @@
 !function (t) {
 	t.fn.responsiveimages = function (i, e) {
-		function r() {
-			old_attrib = c;
-			var i = a.width();
-			t.each(d, function (t, e) {
-				i >= t && (c = "data-" + e)
-			}), old_attrib != c && (l = u), n()
-		}
-
 		function n() {
-			var i = l.filter(function () {
-				var i = t(this);
-				if (!i.is(":hidden")) {
-					var e = t(window).scrollTop(), r = e + t(window).height(), n = i.offset().top, s = n + i.height();
-					return s >= e - h && r + h >= n
-				}
-			});
-			s = i.trigger("responsiveimages"), l = l.not(s)
+			var i = 0;
+			t.each(c, function (t) {
+				i = parseInt(t),
+				w > i && (w = i)
+			})
 		}
-
-		var s, o = {
-			threshold: 0,
-			breakpoints: {320: "small", 720: "medium", 940: "large", 1140: "bigger"}
-		}, i = t.extend({}, o, i), a = t(window), h = i.threshold || 0, d = i.breakpoints, c = (window.devicePixelRatio > 1, "data-src"), l = this, u = this;
+		function r() {
+			var i = "src",
+			e = bp = 0,
+			n = d.width();
+			return w > n ? c[w] : (t.each(c, function (t, r) {
+					bp = parseInt(t),
+					bp <= n && bp > e && (e = bp, i = r)
+				}), i)
+		}
+		function o() {
+			old_attrib = p;
+			var t = r();
+			p = (u ? "data-retina-" : "data-") + t,
+			old_attrib != p && (g = v),
+			a()
+		}
+		function s(i, e) {
+			if (e.preloadClass && i.hasClass(e.preloadClass))
+				return !0;
+			var n,
+			r,
+			o,
+			s = t(e.container),
+			a = i.width(),
+			h = i.height(),
+			l = i.offset().left,
+			c = i.offset().top,
+			u = s.width();
+			return void 0 === e.container || e.container === window ? (n = window.innerHeight ? window.innerHeight : d.height(), r = d.scrollLeft(), o = d.scrollTop()) : (n = s.height(), r = s.offset().left, o = s.offset().top),
+			r + u > l - f && l + a + f > r && o + n > c - f && c + h + f > o
+		}
+		function a() {
+			var e = g.filter(function () {
+					var e = t(this);
+					if (!i.skip_invisible || !e.is(":hidden"))
+						return s(e, i)
+				});
+			h = e.trigger("responsiveimages"),
+			g = g.not(h)
+		}
+		var h,
+		l = {
+			threshold : 0,
+			breakpoints : {
+				0 : "small",
+				480 : "medium",
+				992 : "large",
+				1200 : "bigger"
+			},
+			container : window,
+			skip_invisible : !1,
+			retina : !0,
+			preloadClass : "preload"
+		},
+		i = t.extend({}, l, i),
+		d = t(window),
+		f = i.threshold || 0,
+		c = i.breakpoints,
+		u = i.retina && window.devicePixelRatio > 1,
+		p = "data-src",
+		g = this,
+		v = this,
+		w = 1e16;
 		return this.on("responsiveimages", function () {
-			var t = this.getAttribute(c);
-			t = t || this.getAttribute("data-src"), t && (this.setAttribute("src", t), "function" == typeof e && e.call(this))
-		}), a.scroll(r), a.resize(r), r(), this
+			var t = this.getAttribute(p);
+			t = t || (u ? this.getAttribute("data-" + r()) : !1) || this.getAttribute("data-src"),
+			t && (this.setAttribute("src", t), "function" == typeof e && e.call(this))
+		}),
+		void 0 === t.throttle && (t.throttle = function (t, i) {
+			return i
+		}),
+		t(i.container).scroll(t.throttle(250, o)),
+		d.resize(o),
+		t.fn.responsiveimages.update = o,
+		n(),
+		o(),
+		this
 	}
-}(window.jQuery);
+}
+(window.jQuery);


### PR DESCRIPTION
Extends typo3 6.2-7.0+ bootstrap_package by

Automatically pre-compute real image size for each breakpoint and generate images according.
Use modified jquery.responsiveimages.js to load the right source on each target device.
Adding optional support for retina.
Responsive images are great, but providing images with the right size for each breakpoint and layout is a real pain. The main constrains are :

Devices scree sizes, including retina.
Images sizes not always use the full width of the layout (images beside text, multiple columns...)
Columns width can vary in a single template.
The layouts are changing across breakpoints.
Nested columns layouts are possible with gridelements. (We are about a gridelements columns for bootstrap extension build to take advantage of this extension.)
Here is a working solution adressing nearly every of those cases.