### PR TITLE
[Bugfix] fixes missing localization support in FalViewHelper.php

### DIFF
--- a/Classes/ViewHelpers/DataRelationViewHelper.php
+++ b/Classes/ViewHelpers/DataRelationViewHelper.php
@@ -62,6 +62,7 @@ class DataRelationViewHelper extends AbstractViewHelper {
 					$items[] = $GLOBALS['TSFE']->sys_page->getRecordOverlay($table, $record, $GLOBALS['TSFE']->sys_language_uid);
 				}
 			}
+			 usort($items, array($this,"orderBySorting"));
 		} else {
 			$items = NULL;
 		}
@@ -70,5 +71,7 @@ class DataRelationViewHelper extends AbstractViewHelper {
 		$this->templateVariableContainer->remove($as);
 		return $content;
 	}
+	
+	function orderBySorting($a,$b) { return $a['sorting']>$b['sorting']; }
 
 }

--- a/Classes/ViewHelpers/FalViewHelper.php
+++ b/Classes/ViewHelpers/FalViewHelper.php
@@ -53,6 +53,19 @@ class FalViewHelper extends AbstractViewHelper {
 		if (is_array($data) && $data['uid'] && $data[$field]) {
 			$this->fileRepository = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Resource\\FileRepository');
 			$items = $this->fileRepository->findByRelation($table, $field, $data['uid']);
+			$localizedId = NULL;
+			if (isset($data['_LOCALIZED_UID'])) {
+				$localizedId = $data['_LOCALIZED_UID'];
+			} elseif (isset($element['_PAGES_OVERLAY_UID'])) {
+				$localizedId = $data['_PAGES_OVERLAY_UID'];
+			}
+			$isTableLocalizable = (
+				!empty($GLOBALS['TCA'][$table]['ctrl']['languageField'])
+				&& !empty($GLOBALS['TCA'][$table]['ctrl']['transOrigPointerField'])
+			);
+			if ($isTableLocalizable && $localizedId !== NULL) {
+				$items = $this->fileRepository->findByRelation($table, $field, $localizedId);
+			}
 		} else {
 			$items = NULL;
 		}

--- a/Classes/ViewHelpers/FalViewHelper.php
+++ b/Classes/ViewHelpers/FalViewHelper.php
@@ -56,7 +56,7 @@ class FalViewHelper extends AbstractViewHelper {
 			$localizedId = NULL;
 			if (isset($data['_LOCALIZED_UID'])) {
 				$localizedId = $data['_LOCALIZED_UID'];
-			} elseif (isset($element['_PAGES_OVERLAY_UID'])) {
+			} elseif (isset($data['_PAGES_OVERLAY_UID'])) {
 				$localizedId = $data['_PAGES_OVERLAY_UID'];
 			}
 			$isTableLocalizable = (


### PR DESCRIPTION
the render function in FalViewHelper.php is missing localization
 -> localized background images in the Carousel are not shown in the frontend,
instead the background from the default language is shown.

the changes are "inspired" by sysext/frontend/Classes/Page/PageRepository.php

i am not sure if its needed to include the _PAGES_OVERLAY_UID check, that part may be omitted if the helper will never gets used on page like records.