### PR TITLE
Allow "target" attribute inside <a> tags.

### DIFF
--- a/Configuration/PageTS/RTE.txt
+++ b/Configuration/PageTS/RTE.txt
@@ -332,7 +332,7 @@ RTE.default.proc.entryHTMLparser_db {
 		p.allowedAttribs            = class
 		ol.allowedAttribs           = class
 		ul.allowedAttribs           = class
-		a.allowedAttribs            = class, href, title
+		a.allowedAttribs            = class, href, title, target
 		tr.allowedAttribs           = class
 		th.allowedAttribs           = class
 		td.allowedAttribs           = class


### PR DESCRIPTION
After 884dc4049c8fc21d0678f210aa13abb287ce13fc it's no more possible to specify the target of a link. This edit fixes this.