### PR TITLE
Stop using deprecated XHTML cleaning

### DIFF
--- a/Configuration/PageTS/RTE.txt
+++ b/Configuration/PageTS/RTE.txt
@@ -354,7 +354,6 @@ RTE.default.proc.HTMLparser_db {
 	denyTags < RTE.default.proc.denyTags
 
 	noAttrib = br
-	xhtml_cleaning = 1
 }
 
 ################################################


### PR DESCRIPTION
The bootstrap package still uses xhtml cleaning. That currently gives this deprecation warning (thrown in HtmlParser):

*This section has been deprecated with TYPO3 CMS 7 and will be removed with CMS 8.*

This feature is superfluous nowadays, has been deprecated and is marked for removal from TYPO3 Core.