### PR TITLE
[TASK] Carousel: allow to set the max width of background images

### DIFF
--- a/Configuration/FlexForms/Carousel.xml
+++ b/Configuration/FlexForms/Carousel.xml
@@ -23,6 +23,18 @@
 							</config>
 						</TCEforms>
 					</interval>
+					<background_image_maxwidth>
+						<TCEforms>
+							<label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.background_image_maxwidth
+							</label>
+							<config>
+								<type>input</type>
+								<size>8</size>
+								<default>1920</default>
+								<eval>required,int</eval>
+							</config>
+						</TCEforms>
+					</background_image_maxwidth>
 					<wrap>
 						<TCEforms>
 							<label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.wrap</label>

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -150,6 +150,9 @@
 			<trans-unit id="carousel.interval">
 				<source>Interval in ms</source>
 			</trans-unit>
+			<trans-unit id="carousel.background_image_maxwidth">
+				<source>Max width of background images in px</source>
+			</trans-unit>
 			<trans-unit id="carousel.wrap">
 				<source>Wrap</source>
 			</trans-unit>

--- a/Resources/Private/Templates/ContentElements/Bootstrap/Carousel.html
+++ b/Resources/Private/Templates/ContentElements/Bootstrap/Carousel.html
@@ -14,7 +14,7 @@
 								table="tx_bootstrappackage_carousel_item">
 							<f:if condition="{images}">
 								<bp:var name="backgroundImagePath"
-										value="{f:uri.image(src:'{images.0.uid}',treatIdAsReference: 1)}"/>
+										value="{f:uri.image(src:'{images.0.uid}',treatIdAsReference: 1,maxWidth:'{data.pi_flexform.background_image_maxwidth}')}"/>
 								background-image: url('{backgroundImagePath}');
 								filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='.{backgroundImagePath}',
 								sizingMethod='scale');


### PR DESCRIPTION
Hi @benjaminkott,
this commit allow to set the max width (default 1920px) of background images in carousels BE form.
I think that this can be useful because an editor could upload an image too much big and, without a max width, this image will impact the download time of the page.
Also this option can be useful to limit the max width in other cases, by instance for small carousels.
It shouldn't hurt existing installation.
Let me know if you also find this useful.
Thanks!