### PR TITLE
[FEATURE] CSS source mapping

### DIFF
--- a/Classes/Service/CompileService.php
+++ b/Classes/Service/CompileService.php
@@ -51,6 +51,16 @@ class CompileService {
 				$options = array(
 					'cache_dir' => GeneralUtility::getFileAbsFileName('typo3temp/bootstrappackage')
 				);
+				if ($GLOBALS['TSFE']->tmpl->setup['config.']['cssSourceMapping']) {
+					$optionsForSourceMap = array(
+						'sourceMap'         => true,
+						'sourceMapWriteTo'  => GeneralUtility::getFileAbsFileName('typo3temp/bootstrappackage') . '/bootstrappackage.map',
+						'sourceMapURL'      => '/typo3temp/bootstrappackage/bootstrappackage.map',
+						'sourceMapBasepath' => PATH_site,
+						'sourceMapRootpath' => '/'
+					);
+					$options += $optionsForSourceMap;
+				}
 				$variables = self::getVariablesFromConstants();
 				$files = array();
 				$files[$file] = "";

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -130,6 +130,8 @@ config {
 	admPanel = 1
 	# cat=bootstrap package: advanced/150/180; type=string; label=Header Comment
 	headerComment = Based on the TYPO3 Bootstrap Package by Benjamin Kott - http://www.bk2k.info
+	# cat=bootstrap package: advanced/150/190; type=boolean; label=CSS source mapping: WARNING: this feature needs 'config.compressCss = 0' to work.
+	cssSourceMapping = 0
 }
 
 ##########################

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -564,6 +564,9 @@ config {
 	compressCss = {$config.compressCss}
 	concatenateJs = {$config.concatenateJs}
 	concatenateCss = {$config.concatenateCss}
+
+	// CSS Source Mapping
+	cssSourceMapping = {$config.cssSourceMapping}
 }
 
 #############################


### PR DESCRIPTION
Hi @benjaminkott,
this feature enable CSS source mapping (https://developer.chrome.com/devtools/docs/css-preprocessors) very useful to debug the generated CSS from Less. It's enabled if new constant 'cssSourceMapping = 1' and requires 'config.compressCss = 0'.

Thanks for your attention :)

P.S.:
Can you also take a look at the other pull requests: https://github.com/benjaminkott/bootstrap_package/pull/163 and https://github.com/benjaminkott/bootstrap_package/pull/167?