### PR TITLE
[FEATURE] New advanced constant to enable/disable the use of Typoscript constants as Less variables

### DIFF
--- a/Classes/Service/CompileService.php
+++ b/Classes/Service/CompileService.php
@@ -51,7 +51,11 @@ class CompileService {
 				$options = array(
 					'cache_dir' => GeneralUtility::getFileAbsFileName('typo3temp/bootstrappackage')
 				);
-				$variables = self::getVariablesFromConstants();
+				if ($GLOBALS['TSFE']->tmpl->setup['config.']['lessVariablesFromConstants']) {
+					$variables = self::getVariablesFromConstants();
+				} else {
+					$variables = array();
+				}
 				$files = array();
 				$files[$file] = "";
 				$compiledFile = \Less_Cache::Get($files, $options, $variables);

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -130,6 +130,8 @@ config {
 	admPanel = 1
 	# cat=bootstrap package: advanced/150/180; type=string; label=Header Comment
 	headerComment = Based on the TYPO3 Bootstrap Package by Benjamin Kott - http://www.bk2k.info
+	# cat=bootstrap package: advanced/150/200; type=boolean; label=Less variables from constants: Enable/disable the use of Typoscript constants as Less variables
+	lessVariablesFromConstants = 1
 }
 
 ##########################

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -564,6 +564,9 @@ config {
 	compressCss = {$config.compressCss}
 	concatenateJs = {$config.concatenateJs}
 	concatenateCss = {$config.concatenateCss}
+
+	// Enable/disable the use of Typoscript constants as Less variables
+	lessVariablesFromConstants = {$config.lessVariablesFromConstants}
 }
 
 #############################


### PR DESCRIPTION
Hey @benjaminkott,
this is another patch (the last one) needed to use an external Less processor like Prepros.
This doesn't change the default behaviour of EXT:bootstrap_package but allows advanced users to set a constant to disable the use of Typoscript constants as Less variables.
In this case the user must customize the default Bootstrap variables directly in Less.

Related to:
https://github.com/benjaminkott/bootstrap_package/issues/162
https://github.com/benjaminkott/bootstrap_package/pull/168
