### PR TITLE
[FEATURE] New advanced constant to enable/disable CSS source mapping

### DIFF
--- a/Classes/Service/CompileService.php
+++ b/Classes/Service/CompileService.php
@@ -53,6 +53,22 @@ class CompileService {
 				);
 
 				$settings = ($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_bootstrappackage.']['settings.'] ?: array());
+				if ($settings['cssSourceMapping']) {
+					// enable source mapping
+					$optionsForSourceMap = array(
+						'sourceMap'         => true,
+						'sourceMapWriteTo'  => GeneralUtility::getFileAbsFileName('typo3temp/bootstrappackage') . '/bootstrappackage.map',
+						'sourceMapURL'      => '/typo3temp/bootstrappackage/bootstrappackage.map',
+						'sourceMapBasepath' => PATH_site,
+						'sourceMapRootpath' => '/'
+					);
+					$options += $optionsForSourceMap;
+
+					// disable CSS compression
+					/** @var $pageRenderer \TYPO3\CMS\Core\Page\PageRenderer */
+					$pageRenderer = $GLOBALS['TSFE']->getPageRenderer();
+					$pageRenderer->disableCompressCss();
+				}
 				if ($settings['overrideLessVariables']) {
 					$variables = self::getVariablesFromConstants();
 				} else {

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -155,6 +155,8 @@ plugin.bootstrap_package {
 	settings {
 		# cat=bootstrap package: advanced/190/100; type=boolean; label=Override LESS Variables: If enabled the variables defined in your LESS files will be overritten with the ones defined as TypoScript Constants.
 		overrideLessVariables = 1
+		# cat=bootstrap package: advanced/190/110; type=boolean; label=CSS source mapping: Create a CSS source map useful to debug Less in browser developer tools. Note: CSS compression will be disabled.
+		cssSourceMapping = 0
 	}
 }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -10,6 +10,7 @@
 plugin.tx_bootstrappackage {
 	settings {
 		overrideLessVariables = {$plugin.bootstrap_package.settings.overrideLessVariables}
+		cssSourceMapping = {$plugin.bootstrap_package.settings.cssSourceMapping}
 	}
 }
 


### PR DESCRIPTION
Hi @benjaminkott,
here is the rewrite of this feature (ref. https://github.com/benjaminkott/bootstrap_package/pull/168).

This feature enable CSS source mapping (https://developer.chrome.com/devtools/docs/css-preprocessors) very useful to debug the generated CSS from Less. It's enabled if new constant 'plugin.bootstrap_package.settings.cssSourceMapping = 1'. It will also automatically disable CSS compression.

