### PR TITLE
Update jquery.responsiveimages.js

### DIFF
--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -27,7 +27,8 @@
 		},
 		attrib: "data-src",
 		container: window,
-		skip_invisible: true
+		skip_invisible: false,
+		preload: false
 	};
 	
     ResponsiveImage.prototype.viewportW = function() {
@@ -70,8 +71,8 @@
 	};
 
 	ResponsiveImage.prototype.unveil = function() {
-		if (this.options.skip_invisible && this.$element.is(":hidden")) return;
-		var inview = this.inviewport();
+		if (!this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
+		var inview = this.options.preload || this.inviewport();
 		if(inview){
 			var source = this.$element.attr(this.attrib);
 			source = source || this.$element.attr("data-src");

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -29,9 +29,19 @@
 		container: window,
 		skip_invisible: true
 	};
-
+	
+    ResponsiveImage.prototype.viewportW = function() {
+		var a = document.documentElement['clientWidth'], b = window['innerWidth'];
+        return a < b ? b : a;
+      };
+	  
+    ResponsiveImage.prototype.viewportH = function() {
+        var a = document.documentElement['clientHeight'], b = window['innerHeight'];
+        return a < b ? b : a;
+      };
+      
 	ResponsiveImage.prototype.checkviewport = function() {
-		var containerWidth = this.$container.width();
+		var containerWidth = this.viewportW();
 		var attrib = this.attrib;
 		var old_attrib = this.attrib;
 		$.each(this.options.breakpoints, function (breakpoint, datakey) {
@@ -45,28 +55,18 @@
 		this.unveil();
 	};
 
+	ResponsiveImage.prototype.boundingbox = function() {
+		var o = {},
+			coords    = this.$element[0].getBoundingClientRect(), 
+			threshold = +this.threshold || 0;
+		o['width']  = (o['right'] = coords['right'] + threshold) - (o['left'] = coords['left'] - threshold);
+		o['height'] = (o['bottom'] = coords['bottom'] + threshold) - (o['top'] = coords['top'] - threshold);
+		return o;
+	};
+
 	ResponsiveImage.prototype.inviewport = function() {
-		var elementWidth = this.$element.width(),
-			elementHeight = this.$element.height(),
-			elementLeft = this.$element.offset().left,
-			elementTop = this.$element.offset().top,
-			containerWidth = this.$container.width(),
-			containerHeight,
-			containerLeft,
-			containerTop;
-		if (this.options.container === undefined || this.options.container === window){
-			containerHeight = $(window).innerHeight() ? $(window).innerHeight() : $(window).height();
-			containerLeft = $(window).scrollLeft();
-			containerTop = $(window).scrollTop();
-		} else {
-			containerHeight = this.$container.height();
-			containerLeft = this.$container.offset().left;
-			containerTop = this.$container.offset().top;
-		}
-		return containerLeft + containerWidth > elementLeft - this.options.threshold
-			&& containerLeft < elementLeft + elementWidth + this.options.threshold
-			&& containerTop + containerHeight > elementTop - this.options.threshold
-			&& containerTop < elementTop + elementHeight + this.options.threshold;
+		var bb = this.boundingbox();
+		return !!bb && bb.bottom >= 0 && bb.right >= 0 && bb.top <= this.viewportH() && bb.left <= this.viewportW();
 	};
 
 	ResponsiveImage.prototype.unveil = function() {

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -59,7 +59,7 @@
 	ResponsiveImage.prototype.boundingbox = function() {
 		var o = {},
 			coords    = this.$element[0].getBoundingClientRect(), 
-			threshold = +this.threshold || 0;
+			threshold = +this.options.threshold || 0;
 		o['width']  = (o['right'] = coords['right'] + threshold) - (o['left'] = coords['left'] - threshold);
 		o['height'] = (o['bottom'] = coords['bottom'] + threshold) - (o['top'] = coords['top'] - threshold);
 		return o;


### PR DESCRIPTION
JQuery screen size methods donsen't match media query exact size. 
So the images change too soon.

Using "verge.js" cross browser methods for checkviewport and inviewport fix this issue.

 * Inspired by verge.js
 * https://github.com/ryanve/verge
 * MIT License 2013 Ryan Van Etten