### PR TITLE
Fine tune jquery.responsiveimage.js

### DIFF
--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -50,7 +50,7 @@
 		var old_attrib = this.attrib;
 		$.each(this.options.breakpoints, function (breakpoint, datakey) {
 			if (containerWidth >= breakpoint) {
-				attrib = "data-" + datakey;
+				attrib = datakey;
 			}
 		});
 		if (old_attrib !== attrib) {
@@ -77,11 +77,11 @@
 		if (!this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
 		var inview = this.options.preload || this.inviewport();
 		if(inview){
-			var source = this.$element.attr(this.attrib);
-			source = source || this.$element.attr("data-src");
+			var source = this.options[this.attrib] || this.options["src"];
 			if (source) {
 				this.$element.attr("src", source);
 				this.$element.css("opacity", 1);
+				$(window).trigger('loaded.bk2k.responsiveimage');
 			}
 		}
 	};
@@ -116,7 +116,7 @@
 
 	// RESPONSIVE IMAGES API
 	// =====================
-	$(window).on('load', function() {
+	$(window).on('load.bk2k', function() {
 		$('img.lazyload').each(function() {
 			var $image = $(this);
 			var data = $image.data();

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -14,6 +14,7 @@
 		this.$element	= $(element);
 		this.options	= $.extend({}, ResponsiveImage.DEFAULTS, options);
 		this.attrib 	= "src";
+		this.loaded		= false;
 		this.checkviewport();
 	};
 
@@ -26,7 +27,6 @@
 			1200: 'bigger'
 		},
 		attrib: "src",
-		container: window,
 		skip_invisible: false,
 		preload: false
 	};
@@ -52,8 +52,11 @@
 		});
 		if (old_attrib !== attrib) {
 			this.attrib = attrib;
+			this.loaded	= false;
 		}
-		this.unveil();
+		if (!this.loaded){
+			this.unveil();
+			}
 	};
 
 	ResponsiveImage.prototype.boundingbox = function() {
@@ -79,6 +82,7 @@
 				this.$element.attr("src", source);
 				this.$element.css("opacity", 1);
 				$(window).trigger('loaded.bk2k.responsiveimage');
+				this.loaded	= true;
 			}
 		}
 	};

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -54,9 +54,7 @@
 			this.attrib = attrib;
 			this.loaded	= false;
 		}
-		if (!this.loaded){
-			this.unveil();
-			}
+		this.unveil();
 	};
 
 	ResponsiveImage.prototype.boundingbox = function() {
@@ -74,7 +72,7 @@
 	};
 
 	ResponsiveImage.prototype.unveil = function() {
-		if (!this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
+		if (this.loaded || !this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
 		var inview = this.options.preload || this.inviewport();
 		if(inview){
 			var source = this.options[this.attrib] || this.options["src"];
@@ -129,8 +127,12 @@
 		// EVENT "DELEGATION"
 		// ==================
 		$(window)
-			.off('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage')
-			.on('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage', function(){
+			.off('scroll.bk2k.responsiveimage')
+			.on('scroll.bk2k.responsiveimage', function(){
+				$('img.lazyload').responsiveimage('unveil');
+			})
+			.off('resize.bk2k.responsiveimage')
+			.on('resize.bk2k.responsiveimage', function(){
 				$('img.lazyload').responsiveimage('checkviewport');
 			});
 	});		

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -124,13 +124,15 @@
 
 			Plugin.call($image, data);
 		});
-	});
+
 	
-	// EVENT "DELEGATION"
-	// ==================
-	$(window).on('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage', function(){
-		$('img.lazyload').responsiveimage('checkviewport');
-	});
-		
+		// EVENT "DELEGATION"
+		// ==================
+		$(window)
+			.off('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage')
+			.on('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage', function(){
+				$('img.lazyload').responsiveimage('checkviewport');
+			});
+	});		
 		
 }(jQuery);

--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -13,10 +13,7 @@
 	var ResponsiveImage = function(element, options) {
 		this.$element	= $(element);
 		this.options	= $.extend({}, ResponsiveImage.DEFAULTS, options);
-		this.attrib = "data-src";
-		this.$container = $(this.options.container)
-			.on('scroll.bk2k.responsiveimage', $.proxy(this.checkviewport, this))
-			.on('resize.bk2k.responsiveimage', $.proxy(this.checkviewport, this));
+		this.attrib 	= "src";
 		this.checkviewport();
 	};
 
@@ -28,7 +25,7 @@
 			992: 'large',
 			1200: 'bigger'
 		},
-		attrib: "data-src",
+		attrib: "src",
 		container: window,
 		skip_invisible: false,
 		preload: false
@@ -116,7 +113,7 @@
 
 	// RESPONSIVE IMAGES API
 	// =====================
-	$(window).on('load.bk2k', function() {
+	$(window).on('load.bk2k.responsiveimage', function() {
 		$('img.lazyload').each(function() {
 			var $image = $(this);
 			var data = $image.data();
@@ -124,5 +121,12 @@
 			Plugin.call($image, data);
 		});
 	});
-
+	
+	// EVENT "DELEGATION"
+	// ==================
+	$(window).on('scroll.bk2k.responsiveimage, resize.bk2k.responsiveimage', function(){
+		$('img.lazyload').responsiveimage('checkviewport');
+	});
+		
+		
 }(jQuery);


### PR DESCRIPTION
Hi everybody !

@benjaminkott  Your (or whoever does it) job on this plugin is awsome guys, it's a real pleasure to make some little enhancement 

Line 119  
Add .bk2k namespace to window.on(load) event
Allow re-init plugin when page content does change eg by ajax call. The event namespace is intentionnaly left without .responsiveimage
to allow scroll and resize events to be disabled before ajax content changes without killing the window.load event

```javascript
// Re-init plugin with new content after ajax call
$(window).trigger('load.bk2k');

// Remove events listeners before ajax call
$(window).off('bk2k.responsiveimage');

// Force images update on eg tab change, carousel change... 
$(window).trigger('scroll.bk2k.responsiveimage');
```

Line 84 
There is no more callback on image loaded witch is an issue for content witch depend on layout. (eg bootstrap scrollspy) 
To adress this, one could fire a user event to trig callbacks when images load / change. 
Not optimal since it does fire when image start to load but on the other hand it is damn simple and does work on any browser.

See "Caveats of the load event when used with images", https://api.jquery.com/load-event/
Another cross brother approach to catch image load event exist but are far from being simple see
https://github.com/desandro/imagesloaded/blob/master/imagesloaded.js 

The event is meant to be catched with a setTimeout based handler since many calls are possible, this way make a kind of throttle.

```javascript
var loadedTimeout;
$(window).on('loaded.bk2k.responsiveimage', function(){
	clearTimeout(loadedTimeout);
	loadedTimeout = setTimeout(function(){
		// whatever you want to do 
		refreshScrollSpy();
		}, 200);
	});
```


Line 80 
Source and data-attrib 
When plugin init, all data-attrib are put into options, including sources ones.
So there is no need to get image data-attrib but just this.options[this.attrib]