### PR TITLE
Fix 'overridden' typos

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -161,7 +161,7 @@ styles {
 #########################
 plugin.bootstrap_package {
 	settings {
-		# cat=bootstrap package: advanced/190/100; type=boolean; label=Override LESS Variables: If enabled the variables defined in your LESS files will be overritten with the ones defined as TypoScript Constants.
+		# cat=bootstrap package: advanced/190/100; type=boolean; label=Override LESS Variables: If enabled the variables defined in your LESS files will be overridden with the ones defined as TypoScript Constants.
 		overrideLessVariables = 1
 		# cat=bootstrap package: advanced/190/110; type=boolean; label=CSS source mapping: Create a CSS source map useful to debug Less in browser developer tools. Note: CSS compression will be disabled.
 		cssSourceMapping = 0

--- a/Documentation/Configuration/TypoScript/Index.rst
+++ b/Documentation/Configuration/TypoScript/Index.rst
@@ -9,7 +9,7 @@
 ==========
 TypoScript
 ==========
-Bootstrap Package was built to be as adjustable as possible, so nothing is fixed and everything can be overritten with TypoScript constants.
+Bootstrap Package was built to be as adjustable as possible, so nothing is fixed and everything can be overridden with TypoScript constants.
 The constants are grouped in basic and advanced settings. Use the **TYPO3 Constant Editor** in the backend to modify the values.
 
 .. figure:: ../../Images/Configuration/TypoScriptConstantEditor.jpg


### PR DESCRIPTION
I know this is pedantic, but i keep seeing these...
Can't help myself, I just had to propose a fix.