### PR TITLE
[BUGFIX] Use always $GLOBALS[TCA]

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -65,7 +65,7 @@ unset($backupCTypeItems);
  */
 $tca = array(
 	'ctrl' => array(
-		'requestUpdate' => $TCA['tt_content']['ctrl']['requestUpdate'] . ',icon_type',
+		'requestUpdate' => $GLOBALS['TCA']['tt_content']['ctrl']['requestUpdate'] . ',icon_type',
 		'typeicons' => array(
 			'bootstrap_package_panel' => 'tt_content_header.gif',
 			'bootstrap_package_listgroup' => 'tt_content_header.gif',


### PR DESCRIPTION
this breaks the requestUpdate ctrl string in tt_content, see https://forge.typo3.org/issues/68517