### PR TITLE
[BUGFIX] Make class.ext_update.php work on PHP <5.5 as well

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -65,7 +65,7 @@ class ext_update {
 		}
 		/* @var $flashMessage FlashMessage */
 		$flashMessage = GeneralUtility::makeInstance(
-			FlashMessage::class,
+			'TYPO3\\CMS\\Core\\Messaging\\FlashMessage',
 			'All pages with backend layouts successfully updated',
 			'Migration completed',
 			FlashMessage::OK


### PR DESCRIPTION
TYPO3 6.2 still runs on PHP 5.3/5.4. Using ::class is only
possible starting from PHP 5.5.

Resolves: #213