### PR TITLE
Add useful RTE buttons

### DIFF
--- a/Configuration/PageTS/RTE.txt
+++ b/Configuration/PageTS/RTE.txt
@@ -187,7 +187,8 @@ RTE.default {
         chMode, table, tableproperties, toggleborders, tablerestyle,
         rowproperties, rowinsertabove, rowinsertunder, rowdelete, rowsplit,
         columnproperties, columninsertbefore, columninsertafter, columndelete, columnsplit,
-        cellproperties, cellinsertbefore, cellinsertafter, celldelete, cellsplit, cellmerge
+        cellproperties, cellinsertbefore, cellinsertafter, celldelete, cellsplit, cellmerge,
+		insertcharacter, findreplace
     )
 
     // Define buttons and order of button that will be shown


### PR DESCRIPTION
The insertcharacter and findreplace buttons added here are in the htmlArea RTE's default "Typical" configuration, so editors may expect to see them.