### PR TITLE
Carousel header should not be required

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -310,7 +310,7 @@ return array(
             'config' => array(
                 'type' => 'input',
                 'size' => 50,
-                'eval' => 'trim,required'
+                'eval' => 'trim'
             ),
         ),
         'header_layout' => array(

--- a/Resources/Private/Partials/ContentElements/Carousel/Item/Header.html
+++ b/Resources/Private/Partials/ContentElements/Carousel/Item/Header.html
@@ -1,7 +1,11 @@
-<div class="valign" {f:if(condition: item.text_color,then:'style="color: {item.text_color};"')}>
-    <div class="vcontainer">
-        <div class="carousel-text-inner">
-            <h{item.header_layout} class="text-center awesome">{item.header}</h{item.header_layout}>
-        </div>
-    </div>
-</div>
+<f:if condition="{item.header}">
+	<f:then>
+		<div class="valign" {f:if(condition: item.text_color,then:'style="color: {item.text_color};"')}>
+			<div class="vcontainer">
+				<div class="carousel-text-inner">
+					<h{item.header_layout} class="text-center awesome">{item.header}</h{item.header_layout}>
+				</div>
+			</div>
+		</div>
+	</f:then>
+</f:if>

--- a/Resources/Private/Partials/ContentElements/Carousel/Item/TextAndImage.html
+++ b/Resources/Private/Partials/ContentElements/Carousel/Item/TextAndImage.html
@@ -1,7 +1,11 @@
 {namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <div class="valign">
     <div class="carousel-text vcontainer lead" {f:if(condition: item.text_color,then: 'style="color: {item.text_color};"')}>
-        <h{item.header_layout}>{item.header}</h{item.header_layout}>
+		<f:if condition="{item.header}">
+			<f:then>
+				<h{item.header_layout}>{item.header}</h{item.header_layout}>
+			</f:then>
+		</f:if>
         <f:format.html>{item.bodytext}</f:format.html>
     </div>
     <div class="carousel-image vcontainer">


### PR DESCRIPTION
The carousel header field should behave like tt_content.header, which is not a required field.
