### PR TITLE
Language menu auto-hides if there are no sys_language records

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -40,8 +40,20 @@ plugin.tx_bootstrappackage {
 #######################
 #### LANGUAGE MENU ####
 #######################
+lib.languageCount = CONTENT
+lib.languageCount {
+	table = sys_language
+	select.selectFields = count(*)
+	select.pidInList = root
+	renderObj = TEXT
+	renderObj.field = count(*)
+}
+
 lib.language = COA
 lib.language {
+	# Render menu only if there are language records.
+	if.isTrue.cObject < lib.languageCount
+
     ###################################################
     #### EXAMPLE FOR TYPOSCRIPT LANGUAGE OVERRIDES ####
     #### its not needed in this example            ####

--- a/Resources/Private/Partials/Page/Structure/Footer.html
+++ b/Resources/Private/Partials/Page/Structure/Footer.html
@@ -16,17 +16,28 @@
 </section>
 
 <section class="meta-section">
-    <div class="container">
-        <div class="row">
-            <div class="col-md-4 language">
-                <f:cObject typoscriptObjectPath="lib.language"/>
-            </div>
-            <f:if condition="{themeCopyright}">
-                <div class="col-md-8 copyright" role="contentinfo">
-                    <f:format.html>{themeCopyrightText}</f:format.html>
-                </div>
-            </f:if>
-        </div>
-    </div>
+	<div class="container">
+		<div class="row">
+			<f:if condition="{f:cObject(typoscriptObjectPath: 'lib.languageCount')}">
+				<f:then>
+					<div class="col-md-4 language">
+						<f:cObject typoscriptObjectPath="lib.language"/>
+					</div>
+					<f:if condition="{themeCopyright}">
+						<div class="col-md-8 copyright" role="contentinfo">
+							<f:format.html>{themeCopyrightText}</f:format.html>
+						</div>
+					</f:if>
+				</f:then>
+				<f:else>
+					<f:if condition="{themeCopyright}">
+						<div class="col-md-12 copyright" role="contentinfo">
+							<f:format.html>{themeCopyrightText}</f:format.html>
+						</div>
+					</f:if>
+				</f:else>
+			</f:if>
+		</div>
+	</div>
 </section>
 </footer>


### PR DESCRIPTION
The menu itself does not auto-configure for actual language records in the website, but at
least now it won't show up when bootstrap_package is installed on a site with no language records.

See discussions in #30, #71 and #122
