### PR TITLE
[BUGFIX] Fix behaviour of strictly allowed RTE classes

### DIFF
--- a/Configuration/PageTS/RTE.txt
+++ b/Configuration/PageTS/RTE.txt
@@ -291,17 +291,23 @@ RTE.default.proc.entryHTMLparser_db {
             rmTagIfNoAttrib = 1
         }
 
-        h1.fixAttrib.class.list     = lead, text-left, text-center, text-right, text-justify
-        h2.fixAttrib.class.list     = lead, text-left, text-center, text-right, text-justify
-        h3.fixAttrib.class.list     = lead, text-left, text-center, text-right, text-justify
-        h4.fixAttrib.class.list     = lead, text-left, text-center, text-right, text-justify
+        // Only the classs mentioned in these lists, are allowed on db-entry parsing
+        // Which means if a element enters the db, all classes on the element will
+        // get removed *except* those mentioned here.
+        // It's important to mention the "emtpy" list element here, denoted with
+        // the leading comma, otherwise the first element get's applied *automatically*
+        // Bug or feature!?
+        h1.fixAttrib.class.list     = , lead, text-left, text-center, text-right, text-justify
+        h2.fixAttrib.class.list     = , lead, text-left, text-center, text-right, text-justify
+        h3.fixAttrib.class.list     = , lead, text-left, text-center, text-right, text-justify
+        h4.fixAttrib.class.list     = , lead, text-left, text-center, text-right, text-justify
 
-        p.fixAttrib.class.list      = lead, text-left, text-center, text-right, text-justify
+        p.fixAttrib.class.list      = , lead, text-left, text-center, text-right, text-justify
 
-        ol.fixAttrib.class.list     = list-unstyled, list-inline
-        ul.fixAttrib.class.list     = list-unstyled, list-inline
+        ol.fixAttrib.class.list     = , list-unstyled, list-inline
+        ul.fixAttrib.class.list     = , list-unstyled, list-inline
 
-        a.fixAttrib.class.list      = btn, btn-default, btn-primary, btn-success, btn-warning, btn-danger, btn-link, btn-block
+        a.fixAttrib.class.list      = , btn, btn-default, btn-primary, btn-success, btn-warning, btn-danger, btn-link, btn-block
 
         // Disallow all attributes
         hr.allowedAttribs           = 0


### PR DESCRIPTION
The list of allowed classes missed the "empty" element, which auto-fixed
not-allowed classes to get the first class assigned automatically.

Example:

```
RTE.default.proc.entryHTMLparser_db {
    p.fixAttrib.class.list = lead, text-left, text-center
}
```

Source:

```
<p class="cool-legacy-class">..Bla..</p>
```

Will get cleaned up to

```
<p class="lead">..Bla..</p>
```

Adding the empty list-element fixes this faulty behaviour:

```
RTE.default.proc.entryHTMLparser_db {
    p.fixAttrib.class.list = , lead, text-left, text-center
}
```