### PR TITLE
Force preload images to allow print

### DIFF
--- a/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
+++ b/Resources/Public/JavaScript/Libs/jquery.responsiveimages.js
@@ -103,9 +103,9 @@
         return viewport.inviewport(boundingbox);
     };
 
-    ResponsiveImage.prototype.unveil = function() {
-        if (this.loaded || !this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
-        var inview = this.options.preload || this.inviewport();
+    ResponsiveImage.prototype.unveil = function(force) {
+        if (this.loaded || !force && !this.options.preload && this.options.skip_invisible && this.$element.is(":hidden")) return;
+        var inview = force || this.options.preload || this.inviewport();
         if(inview){
             var source = this.options[this.attrib] || this.options["src"];
             if (source) {
@@ -116,7 +116,10 @@
             }
         }
     };
-
+    
+    ResponsiveImage.prototype.print = function() {
+        this.unveil(true);
+    }
 
     // RESPONSIVE IMAGES PLUGIN DEFINITION
     // ===================================
@@ -168,6 +171,10 @@
             .on('resize.bk2k.responsiveimage', function(){
                 if (viewport) viewport.update();
                 $lazyload.responsiveimage('checkviewport');
+            })
+            .on('beforeprint.bk2k.responsiveimage', function(){
+                $lazyload.responsiveimage('print');
+                $(window).trigger("readytoprint.bk2k.responsiveimage");
             });
     });
 


### PR DESCRIPTION
Add js support to load all images before printing
Note : another option is to set a data-preload="true" attribute to your images.

```javascript
 $(window).on("readytoprint.bk2k.responsiveimage", function(){
    // images urls are ready to print
 });
 $(window).trigger("beforeprint.bk2k.responsiveimage");
```