### PR TITLE
Force preload images to allow print

### DIFF
--- a/Configuration/TypoScript/ContentElement/CssStyledContent.txt
+++ b/Configuration/TypoScript/ContentElement/CssStyledContent.txt
@@ -43,9 +43,10 @@ tt_content.image.20.1 {
         }
     }
 
-    params = class="lazyload"
-    params.override = data-preload="true" class="lazyload"
-    params.override.if.isTrue = {$config.preloadImages}
+    params.stdWrap.cObject = TEXT
+    params.stdWrap.cObject.value = class="lazyload"
+    params.stdWrap.cObject.override = data-preload="true" class="lazyload"
+    params.stdWrap.cObject.override.if.isTrue = {$config.preloadImages}
 }
 
 ###########################

--- a/Configuration/TypoScript/ContentElement/CssStyledContent.txt
+++ b/Configuration/TypoScript/ContentElement/CssStyledContent.txt
@@ -44,6 +44,8 @@ tt_content.image.20.1 {
     }
 
     params = class="lazyload"
+    params.override = data-preload="true" class="lazyload"
+    params.override.if.isTrue = {$config.preloadImages}
 }
 
 ###########################

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -143,6 +143,8 @@ config {
     prefixLocalAnchors = all
     # cat=bootstrap package: advanced/150/190; type=string; label=Header Comment
     headerComment = Based on the TYPO3 Bootstrap Package by Benjamin Kott - http://www.bk2k.info
+    # cat=bootstrap package: advanced/150/200; type=boolean; label=Force images preload: Preload images even when not visible on page to allow print
+    preloadImages = 0
 }
 
 ##########################


### PR DESCRIPTION
Force image preload even when not visible on page to allow print. 
Use lazyload js plugin, but disable inviewport check so all images are loaded right after page load.

Adds config.preloadImages constant to enable this feature on site/per page basis.