### PR TITLE
[BUGFIX] Add namespace to ext_update class

### DIFF
--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -1,4 +1,5 @@
 <?php
+namespace BK2K\BootstrapPackage;
 
 /*
  *  The MIT License (MIT)


### PR DESCRIPTION
Add a namespace to the ext_update class to support installation via composer.
Without namespace composer will throw a warning about ambiguous class resolution.

```
Warning: Ambiguous class resolution, "ext_update" was found in both "$baseDir . '/typo3conf/ext/extension-a/class.ext_update.php" and /typo3conf/ext/extension-b/class.ext_update.php", the first will be used.
```

Similar errors exist in other extensions, see https://forge.typo3.org/issues/70541.