### PR TITLE
[!!!][TASK] Send cache headers per default

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -143,6 +143,8 @@ config {
     headerComment = Based on the TYPO3 Bootstrap Package by Benjamin Kott - http://www.bk2k.info
     # cat=bootstrap package: advanced/150/200; type=boolean; label=Force images preload: Preload images even when not visible on page to allow print
     preloadImages = 0
+    # cat=bootstrap package: advanced/150/210; type=boolean; label=Send cache headers: Allow appropriate caching by transparent proxies and browser clients
+    sendCacheHeaders = 1
 }
 
 ###############

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -503,7 +503,7 @@ config {
     admPanel = {$config.admPanel}
     debug = 0
     cache_period = 86400
-    sendCacheHeaders = 0
+    sendCacheHeaders = {$config.sendCacheHeaders}
     intTarget =
     extTarget =
     disablePrefixComment = 1


### PR DESCRIPTION
Configurable through TS constant `config.sendCacheHeaders`
and through the constants editor.

Closes: #283