### PR TITLE
[TASK] make copyright text more customizable

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -120,6 +120,13 @@ lib.page.class {
     }
 }
 
+###################
+#### COPYRIGHT ####
+###################
+lib.copyrightText = TEXT
+lib.copyrightText {
+    value = {$page.theme.copyright.text}
+}
 
 ##############
 #### PAGE ####
@@ -281,7 +288,6 @@ page {
             }
             copyright {
                 enable = {$page.theme.copyright.enable}
-                text = {$page.theme.copyright.text}
             }
         }
 
@@ -313,6 +319,7 @@ page {
                     if.isTrue = {$page.logo.alt}
                 }
             }
+			copyrightText < lib.copyrightText
             pageClass < lib.page.class
         }
 

--- a/Resources/Private/Partials/Page/Structure/Footer.html
+++ b/Resources/Private/Partials/Page/Structure/Footer.html
@@ -26,7 +26,7 @@
             </div>
             <f:if condition="{settings.copyright.enable}">
                 <div class="col-md-8 copyright" role="contentinfo">
-                    <f:format.html>{settings.copyright.text}</f:format.html>
+					<f:format.html>{copyrightText}</f:format.html>
                 </div>
             </f:if>
         </div>


### PR DESCRIPTION
This patch moves the copyright text from settings to variables cause:
1. a copyright text is more a variable than a setting
2. it can be easily customized extending lib.copyrightText without the need to override the partial
3. it's backward compatible cause it initially gets the value from the constant