### PR TITLE
[TASK] make copyright text more customizable

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -45,7 +45,13 @@ page {
             # cat=bootstrap package: basic/160/120; type=boolean; label=Copyright: Enable to display the copyright
             enable = 1
             # cat=bootstrap package: basic/160/121; type=string; label=Copyright Text
-            text = Built on a Windows 10 Surface Pro. Running with <a href="http://www.typo3.org" target="_blank">TYPO3</a>. Made with <span class="glyphicon glyphicon-heart"></span> by <a href="http://www.bk2k.info" target="_blank">Benjamin Kott</a>
+            text = Built on a Windows 10 Surface Pro. Running with <a href="http://www.typo3.org" target="_blank">TYPO3</a>.
+        }
+        credits {
+            # cat=bootstrap package: basic/160/122; type=boolean; label=Credits: Enable to display the credits
+            enable = 1
+            # cat=bootstrap package: basic/160/123; type=string; label=Credits Text
+            text = Made with <span class="glyphicon glyphicon-heart"></span> by <a href="http://www.bk2k.info" target="_blank">Benjamin Kott</a>
         }
 
         footersection {

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -128,6 +128,14 @@ lib.copyrightText {
     value = {$page.theme.copyright.text}
 }
 
+#################
+#### CREDITS ####
+#################
+lib.creditsText = TEXT
+lib.creditsText {
+    value = {$page.theme.credits.text}
+}
+
 ##############
 #### PAGE ####
 ##############
@@ -289,6 +297,9 @@ page {
             copyright {
                 enable = {$page.theme.copyright.enable}
             }
+            credits {
+                enable = {$page.theme.credits.enable}
+            }
         }
 
         #################
@@ -320,6 +331,7 @@ page {
                 }
             }
             copyrightText < lib.copyrightText
+            creditsText < lib.creditsText
             pageClass < lib.page.class
         }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -120,6 +120,13 @@ lib.page.class {
     }
 }
 
+###################
+#### COPYRIGHT ####
+###################
+lib.copyrightText = TEXT
+lib.copyrightText {
+    value = {$page.theme.copyright.text}
+}
 
 ##############
 #### PAGE ####
@@ -281,7 +288,6 @@ page {
             }
             copyright {
                 enable = {$page.theme.copyright.enable}
-                text = {$page.theme.copyright.text}
             }
         }
 
@@ -313,6 +319,7 @@ page {
                     if.isTrue = {$page.logo.alt}
                 }
             }
+            copyrightText < lib.copyrightText
             pageClass < lib.page.class
         }
 

--- a/Resources/Private/Partials/Page/Structure/Footer.html
+++ b/Resources/Private/Partials/Page/Structure/Footer.html
@@ -26,7 +26,7 @@
             </div>
             <f:if condition="{settings.copyright.enable}">
                 <div class="col-md-8 copyright" role="contentinfo">
-                    <f:format.html>{settings.copyright.text}</f:format.html>
+                    <f:format.html>{copyrightText}</f:format.html>
                 </div>
             </f:if>
         </div>

--- a/Resources/Private/Partials/Page/Structure/Footer.html
+++ b/Resources/Private/Partials/Page/Structure/Footer.html
@@ -26,7 +26,7 @@
             </div>
             <f:if condition="{settings.copyright.enable}">
                 <div class="col-md-8 copyright" role="contentinfo">
-                    <f:format.html>{copyrightText}</f:format.html>
+                    <f:format.html>{copyrightText}<f:if condition="{settings.credits.enable}"> {creditsText}</f:if></f:format.html>
                 </div>
             </f:if>
         </div>


### PR DESCRIPTION
This patch moves the copyright text from settings to variables cause:
1. a copyright text is more a variable than a setting
2. it can be easily customized extending lib.copyrightText without the need to override the partial
3. it's backward compatible cause it initially gets the value from the constant