### PR TITLE
[FEATURE] allow BE user to select the crop ratio of images

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -6,7 +6,8 @@
 $GLOBALS['TCA']['tt_content']['palettes']['imageblock'] = [
     'showitem' => '
         imageorient,
-        imagecols'
+        imagecols,
+        image_crop_ratio'
 ];
 $GLOBALS['TCA']['tt_content']['palettes']['mediablock'] = [
     'showitem' => '
@@ -592,7 +593,7 @@ $tca = array(
                 header_layout;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header_layout_formlabel,
                 --linebreak--,
                 header_link;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header_link_formlabel
-			'
+            '
         ),
         'bootstrap_package_headersimple' => array(
             'canNotCollapse' => 1,
@@ -600,7 +601,7 @@ $tca = array(
                 header;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header_formlabel,
                 --linebreak--,
                 header_layout;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:header_layout_formlabel
-			'
+            '
         ),
         'bootstrap_package_icons' => array(
             'canNotCollapse' => 1,
@@ -608,14 +609,14 @@ $tca = array(
                 icon_position, icon_type, icon_size, --linebreak--,
                 icon_color, icon_background, --linebreak--,
                 icon
-			'
+            '
         ),
         'bootstrap_package_external_media' => array(
             'canNotCollapse' => 1,
             'showitem' => '
                 external_media_source, --linebreak--,
                 external_media_ratio
-			'
+            '
         ),
     ),
     'types' => array(
@@ -643,7 +644,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_listgroup' => array(
             'columnsOverrides' => array(
@@ -663,7 +664,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_accordion' => array(
             'showitem' => '
@@ -678,7 +679,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_tab' => array(
             'showitem' => '
@@ -695,7 +696,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_carousel' => array(
             'showitem' => '
@@ -712,7 +713,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_texticon' => array(
             'columnsOverrides' => array(
@@ -734,7 +735,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
         'bootstrap_package_external_media' => array(
             'showitem' => '
@@ -749,7 +750,7 @@ $tca = array(
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.extended,
                 --div--;LLL:EXT:lang/locallang_tca.xlf:sys_category.tabs.category,
                 categories
-			'
+            '
         ),
     ),
     'columns' => array(
@@ -1906,6 +1907,17 @@ $tca = array(
                 'items' => array(
                     array('16:9', '16by9'),
                     array('4:3', '4by3'),
+                ),
+            ),
+        ),
+        'image_crop_ratio' => array(
+            'label' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.image_crop_ratio',
+            'config' => array(
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'items' => array(
+                    array('', ''),
+                    array('1:1', '1by1'),
                 ),
             ),
         ),

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -344,6 +344,10 @@
                 <source>Ratio</source>
             </trans-unit>
 
+            <trans-unit id="field.image_crop_ratio">
+                <source>Image crop ratio</source>
+            </trans-unit>
+
             <trans-unit id="field.icon">
                 <source>Icon</source>
             </trans-unit>

--- a/Resources/Private/Partials/ContentElements/Media/Image.html
+++ b/Resources/Private/Partials/ContentElements/Media/Image.html
@@ -3,18 +3,18 @@
     <f:if condition="{file.link}">
         <f:then>
             <f:link.typolink parameter="{file.link}" title="{file.title}">
-                <f:render partial="Media/Rendering/Image" arguments="{file: file, settings: settings}" />
+                <f:render partial="Media/Rendering/Image" arguments="{file: file, data: data, settings: settings}" />
             </f:link.typolink>
         </f:then>
         <f:else>
             <f:if condition="{data.image_zoom}">
                 <f:then>
                     <a href="{f:uri.image(image: file, maxHeight: '1200', maxWidth: '1200')}" title="{file.title}" class="{settings.lightbox.cssClass}" data-lightbox-width="{bk2k:lastImageInfo(property: 'width')}" data-lightbox-height="{bk2k:lastImageInfo(property: 'height')}" rel="{settings.lightbox.prefix}-{data.uid}">
-                        <f:render partial="Media/Rendering/Image" arguments="{file: file, settings: settings}" />
+                        <f:render partial="Media/Rendering/Image" arguments="{file: file, data: data, settings: settings}" />
                     </a>
                 </f:then>
                 <f:else>
-                    <f:render partial="Media/Rendering/Image" arguments="{file: file, settings: settings}" />
+                    <f:render partial="Media/Rendering/Image" arguments="{file: file, data: data, settings: settings}" />
                 </f:else>
             </f:if>
         </f:else>

--- a/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
+++ b/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
@@ -1,9 +1,26 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
+
+<bk2k:var name="maxWidthBigger" value="1140" />
+<bk2k:var name="maxWidthLarge" value="940" />
+<bk2k:var name="maxWidthMedium" value="720" />
+<bk2k:var name="maxWidthSmall" value="320" />
+
 <img src="{f:uri.image(src: 'EXT:bootstrap_package/Resources/Public/Images/blank.gif')}"
      data-src="{f:uri.image(image: file)}"
-     data-bigger="{f:uri.image(image: file, maxWidth: 1140)}"
-     data-large="{f:uri.image(image: file, maxWidth: 940)}"
-     data-medium="{f:uri.image(image: file, maxWidth: 720)}"
-     data-small="{f:uri.image(image: file, maxWidth: 320)}"
+     <f:switch expression="{data.image_crop_ratio}">
+        <f:case value="1by1">
+            data-bigger="{f:uri.image(image: file, width: '{maxWidthBigger}c', height: '{maxWidthBigger}c', maxWidth: '{maxWidthBigger}', maxHeight: '{maxWidthBigger}', minWidth: '{maxWidthBigger}', minHeight: '{maxWidthBigger}')}"
+            data-large="{f:uri.image(image: file, width: '{maxWidthBigger}c', height: '{maxWidthBigger}c', maxWidth: '{maxWidthBigger}', maxHeight: '{maxWidthBigger}', minWidth: '{maxWidthBigger}', minHeight: '{maxWidthBigger}')}"
+            data-medium="{f:uri.image(image: file, width: '{maxWidthMedium}c', height: '{maxWidthMedium}c', maxWidth: '{maxWidthMedium}', maxHeight: '{maxWidthMedium}', minWidth: '{maxWidthMedium}', minHeight: '{maxWidthMedium}')}"
+            data-small="{f:uri.image(image: file, width: '{maxWidthSmall}c', height: '{maxWidthSmall}c', maxWidth: '{maxWidthSmall}', maxHeight: '{maxWidthSmall}', minWidth: '{maxWidthSmall}', minHeight: '{maxWidthSmall}')}"
+        </f:case>
+        <f:case default="TRUE">
+            data-bigger="{f:uri.image(image: file, maxWidth: '{maxWidthBigger}')}"
+            data-large="{f:uri.image(image: file, maxWidth: '{maxWidthLarge}')}"
+            data-medium="{f:uri.image(image: file, maxWidth: '{maxWidthMedium}')}"
+            data-small="{f:uri.image(image: file, maxWidth: '{maxWidthSmall}')}"
+        </f:case>
+     </f:switch>
      title="{file.title}"
      alt="{file.alternative}"
      class="lazyload"

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE tt_content (
     icon_background varchar(255) DEFAULT '' NOT NULL,
     external_media_source varchar(1024) DEFAULT '' NOT NULL,
     external_media_ratio varchar(10) DEFAULT '' NOT NULL,
+    image_crop_ratio varchar(10) DEFAULT '' NOT NULL,
     tx_bootstrappackage_carousel_item int(11) unsigned DEFAULT '0',
     tx_bootstrappackage_accordion_item int(11) unsigned DEFAULT '0',
     tx_bootstrappackage_tab_item int(11) unsigned DEFAULT '0',


### PR DESCRIPTION
This feature is useful to display all the images of a gallery with the same crop but leaves the images with the original aspect when click enlarged. This crop method is different from cropping each image in the TYPO3 BE 'Image manipulation' cause in the latter also the click enlarged images will be cropped.

Initially only a square 1:1 crop is implemented but can be expanded in the future.