### PR TITLE
[FEATURE] add frame without vertical margins

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -69,7 +69,8 @@ $GLOBALS['TCA']['tt_content']['columns']['section_frame'] = [
             ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.indentleft','11'],
             ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.indentright','12'],
             ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.well','20'],
-            ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.jumbotron','21']
+            ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.jumbotron','21'],
+            ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.section_frame.noverticalmargin','22']
         ],
         'default' => '0'
     ]

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -479,6 +479,9 @@
             <trans-unit id="field.section_frame.jumbotron">
                 <source>Jumbotron</source>
             </trans-unit>
+            <trans-unit id="field.section_frame.noverticalmargin">
+                <source>No vertical margin</source>
+            </trans-unit>
 
             <trans-unit id="field.header_position">
                 <source>Alignment</source>

--- a/Resources/Private/Layouts/ContentElements/Default.html
+++ b/Resources/Private/Layouts/ContentElements/Default.html
@@ -10,6 +10,7 @@
         <f:case value="12"><bk2k:var name="sectionClass" value="col-xs-9" /></f:case>
         <f:case value="20"><bk2k:var name="sectionClass" value="well" /></f:case>
         <f:case value="21"><bk2k:var name="sectionClass" value="jumbotron" /></f:case>
+        <f:case value="22"><bk2k:var name="sectionClass" value="no-vertical-margin" /></f:case>
         <f:case default="TRUE"><bk2k:var name="sectionClass" value="default" /></f:case>
     </f:switch>
 

--- a/Resources/Public/Less/Theme/frame.less
+++ b/Resources/Public/Less/Theme/frame.less
@@ -5,6 +5,11 @@
     margin-top: @line-height-computed * 2;
     margin-bottom: @line-height-computed * 2;
 
+    &.no-vertical-margin {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
     &.rulerbefore {
         border-top: 1px solid @page-header-border-color;
         padding-top: @line-height-computed * 2;


### PR DESCRIPTION
This feature adds a new item "No vertical margin" to the Frame in Content Element Layout. Since frames now have a top and bottom margin by default, this is useful to allow a frame to attach to another object if this also has no margin (e.g.: a carousel can be attached to the header with no space between them).