### PR TITLE
[FEATURE] Remaining PageTS templates are configurable

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -43,3 +43,17 @@ $extensionKey = 'bootstrap_package';
     'Configuration/PageTS/RTE.txt',
     'Bootstrap Package: RTE'
 );
+
+// TtContent Previews
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
+    $extensionKey,
+    'Configuration/PageTS/Mod/WebLayout/TtContent/preview.txt',
+    'Bootstrap Package: Content Previews'
+);
+
+// New Content element wizards
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
+    $extensionKey,
+    'Configuration/PageTS/Mod/Wizards/newContentElement.txt',
+    'Bootstrap Package: New Content Element Wizards'
+);

--- a/Resources/Private/Language/ExtConfTemplate.xlf
+++ b/Resources/Private/Language/ExtConfTemplate.xlf
@@ -28,7 +28,13 @@
                 <source>Disable admPanel: If this option is set the config for admPanel will not load automatically. Include "FILE:EXT:bootstrap_package/Configuration/PageTS/admPanel.txt" in your PageTsConfig to load the config manually.</source>
             </trans-unit>
             <trans-unit id="pageTs.disablePageTsBackendLayouts">
-                <source>Disable BackendLayouts: If this option is set the included backend layouts will not load automatically. Include "FILE:EXT:bootstrap_package/Configuration/PageTS/Mod/web_layout.txt" in your PageTsConfig to load the config manually.</source>
+                <source>Disable BackendLayouts: If this option is set the included backend layouts will not load automatically. Include "FILE:EXT:bootstrap_package/Configuration/PageTS/Mod/WebLayout/BackendLayouts.txt" in your PageTsConfig to load the config manually.</source>
+            </trans-unit>
+            <trans-unit id="pageTs.disablePageTsTtContentPreviews">
+                <source>Disable tt_content types preview: If this option is set, the included content previews for the page module will not be used. Include "FILE:EXT:bootstrap_package/Configuration/PageTS/Mod/WebLayout/TtContent/preview.txt" in your PageTsConfig to load the config manually.</source>
+            </trans-unit>
+            <trans-unit id="pageTs.disablePageTsNewContentElementWizard">
+                <source>Disable New Content Element Wizard items: If this option is set, the included configuration for the new content element wizard will not be loaded automatically. Include "FILE:EXT:bootstrap_package/Configuration/PageTS/Mod/Wizards/newContentElement.txt" in your PageTsConfig to load the config manually.</source>
             </trans-unit>
 
             <trans-unit id="feature.disableLessProcessing">

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -9,6 +9,12 @@
 # cat=General/130_features/10; type=boolean; label=LLL:EXT:bootstrap_package/Resources/Private/Language/ExtConfTemplate.xlf:feature.disableLessProcessing
 disableLessProcessing = 0
 
+# cat=General/120_pagets/70; type=boolean; label=LLL:EXT:bootstrap_package/Resources/Private/Language/ExtConfTemplate.xlf:pageTs.disablePageTsNewContentElementWizard
+disablePageTsNewContentElementWizard = 0
+
+# cat=General/120_pagets/60; type=boolean; label=LLL:EXT:bootstrap_package/Resources/Private/Language/ExtConfTemplate.xlf:pageTs.disablePageTsTtContentPreviews
+disablePageTsTtContentPreviews = 0
+
 # cat=General/120_pagets/50; type=boolean; label=LLL:EXT:bootstrap_package/Resources/Private/Language/ExtConfTemplate.xlf:pageTs.disablePageTsRTE
 disablePageTsRTE = 0
 

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -20,10 +20,14 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY])) {
  */
 
 // Add Bootstrap Content Elements to newContentElement Wizard
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/PageTS/Mod/Wizards/newContentElement.txt">');
+if (!$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]['disablePageTsNewContentElementWizard']) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/PageTS/Mod/Wizards/newContentElement.txt">');
+}
 
 // Add Previews for Bootstrap Content Elements
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/PageTS/Mod/WebLayout/TtContent/preview.txt">');
+if (!$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]['disablePageTsTtContentPreviews']) {
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:' . $_EXTKEY . '/Configuration/PageTS/Mod/WebLayout/TtContent/preview.txt">');
+}
 
 // Add BackendLayouts BackendLayouts for the BackendLayout DataProvider
 if (!$GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY]['disablePageTsBackendLayouts']) {


### PR DESCRIPTION
Modifies inclusion of

* tt_content previews
* new content element wizard items

in a form that either allows them to be included
via ext_typoscript_setup or not.

This is especially helpful with overrides and migration
paths of existing sites to the bootstrap_package.