### PR TITLE
[TASK] Fix top margin for some elements

### DIFF
--- a/Resources/Public/Less/Theme/frame.less
+++ b/Resources/Public/Less/Theme/frame.less
@@ -23,3 +23,9 @@
     }
 
 }
+
+// Pulls up carousel if is into first frame of main section
+.main-section .frame:nth-of-type(1) .carousel { margin-top: -(@line-height-computed * 2) }
+
+// Zeroes top margin of first .frame if there's a breadcrumb
+.breadcrumb-section + .main-section .frame:nth-of-type(1) { margin-top: 0; }


### PR DESCRIPTION
Since now all frame have top and bottom margins, this commit does two things:
1. Pulls up carousel if it is into first frame of main section so it can attach to the header.
2. Zeroes top margin of first frame if there's a breadcrumb because the latter already have a bottom margin but this can't collapse with the top margin of the first frame cause of clearfix between the two elements. This rule also and mainly avoids misalignment between main column and sub navigation.

More info: https://github.com/benjaminkott/bootstrap_package/issues/306