### PR TITLE
Additional link hover text-decoration causes overwriting

### DIFF
--- a/Resources/Public/Less/Theme/misc.less
+++ b/Resources/Public/Less/Theme/misc.less
@@ -90,13 +90,13 @@ img.lazyload {
 // --------------------------------------------------
 .panel-group {
     margin-bottom: 20px;
-}
-a:hover {
-    text-decoration: none;
-}
-.caret {
-    margin-left: 5px;
-}
-.caption {
-    color: @gray-light;
+    a:hover {
+        text-decoration: none;
+    }
+    .caret {
+        margin-left: 5px;
+    }
+    .caption {
+        color: @gray-light;
+    }
 }


### PR DESCRIPTION
The code below causes that the Constant @link-hover-decoration has no effect. I don't know why this expression is written here. Maybe it should be enveloped by the panel-group?
a:hover {
        text-decoration: none;
    }