### PR TITLE
Remove override for text decoration for a:hover

### DIFF
--- a/Resources/Public/Less/Bootstrap/variables.less
+++ b/Resources/Public/Less/Bootstrap/variables.less
@@ -35,7 +35,7 @@
 //** Link hover color set via `darken()` function.
 @link-hover-color:      darken(@link-color, 15%);
 //** Link hover decoration.
-@link-hover-decoration: underline;
+@link-hover-decoration: none;
 
 
 //== Typography

--- a/Resources/Public/Less/Theme/misc.less
+++ b/Resources/Public/Less/Theme/misc.less
@@ -91,9 +91,6 @@ img.lazyload {
 .panel-group {
     margin-bottom: 20px;
 }
-a:hover {
-    text-decoration: none;
-}
 .caret {
     margin-left: 5px;
 }


### PR DESCRIPTION
The entry in Resources/Public/Less/Theme/misc.less overrides the text decoration for a:hover.