### PR TITLE
Add pages of type 'menu separator' as dropdown-header in the menu

### DIFF
--- a/Classes/DataProcessing/MenuProcessor.php
+++ b/Classes/DataProcessing/MenuProcessor.php
@@ -286,6 +286,8 @@ class MenuProcessor implements DataProcessorInterface
             $this->menuConfig[$i . '.']['expAll'] = $this->menuExpandAll;
             $this->menuConfig[$i . '.']['NO'] = '1';
             $this->menuConfig[$i . '.']['NO.'] = $this->menuLevelConfig;
+            $this->menuConfig[$i . '.']['SPC'] = '1';
+            $this->menuConfig[$i . '.']['SPC.'] = $this->menuConfig[$i . '.']['NO.'];
             $this->menuConfig[$i . '.']['IFSUB'] = '1';
             $this->menuConfig[$i . '.']['IFSUB.'] = $this->menuConfig[$i . '.']['NO.'];
             $this->menuConfig[$i . '.']['ACT'] = '1';

--- a/Resources/Private/Partials/Page/Navigation/Main.html
+++ b/Resources/Private/Partials/Page/Navigation/Main.html
@@ -36,11 +36,20 @@
                                     </a>
                                     <ul class="dropdown-menu">
                                         <f:for each="{mainnavigationItem.children}" as="child">
-                                            <li class="{f:if(condition: child.active, then:'active')}">
-                                                <f:link.page pageUid="{child.data.uid}" title="{child.title}">
-                                                    {child.title}
-                                                </f:link.page>
-                                            </li>
+                                            <f:if condition="{child.data.isSpacer}">
+                                                <f:then>
+                                                    <li class="dropdown-header">
+                                                        {child.title}
+                                                    </li>
+                                                </f:then>
+                                                <f:else>
+                                                    <li class="{f:if(condition: child.active, then:'active')}">
+                                                        <f:link.page pageUid="{child.data.uid}" title="{child.title}">
+                                                            {child.title}
+                                                        </f:link.page>
+                                                    </li>
+                                                </f:else>
+                                            </f:if>
                                         </f:for>
                                     </ul>
                                 </f:then>


### PR DESCRIPTION
Allow to have "menu separator" pages rendered as dropdown headers in the main navbar