### PR TITLE
[BUGFIX] Prevent double escaping of menu titles

### DIFF
--- a/Resources/Private/Partials/Page/Navigation/Breadcrumb.html
+++ b/Resources/Private/Partials/Page/Navigation/Breadcrumb.html
@@ -8,11 +8,11 @@
                         <li class="{f:if(condition: item.current, then: 'active')}">
                             <f:if condition="{item.current}">
                                 <f:then>
-                                    {item.title}
+                                    {item.title -> f:format.raw()}
                                 </f:then>
                                 <f:else>
                                     <f:link.page pageUid="{item.data.uid}" title="{item.title}">
-                                        {item.title}
+                                        {item.title -> f:format.raw()}
                                     </f:link.page>
                                 </f:else>
                             </f:if>

--- a/Resources/Private/Partials/Page/Navigation/Main.html
+++ b/Resources/Private/Partials/Page/Navigation/Main.html
@@ -30,7 +30,7 @@
                             <f:if condition="{mainnavigationItem.children}">
                                 <f:then>
                                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                                        {mainnavigationItem.title}
+                                        {mainnavigationItem.title -> f:format.raw()}
                                         <b class="caret"></b>
                                         <span class="bar"></span>
                                     </a>
@@ -45,8 +45,8 @@
                                     </ul>
                                 </f:then>
                                 <f:else>
-                                    <f:link.page pageUid="{mainnavigationItem.data.uid}" title="{mainnavigationItem.title}">
-                                        {mainnavigationItem.title}
+                                    <f:link.page pageUid="{mainnavigationItem.data.uid}" title="{mainnavigationItem.title -> f:format.raw(}">
+                                        {mainnavigationItem.title -> f:format.raw()}
                                         <span class="bar"></span>
                                     </f:link.page>
                                 </f:else>

--- a/Resources/Private/Partials/Page/Navigation/Subnavigation.html
+++ b/Resources/Private/Partials/Page/Navigation/Subnavigation.html
@@ -9,8 +9,8 @@
 <f:section name="SubnavigationItem">
     <f:for each="{menu}" as="item">
         <li class="{f:if(condition: item.active, then:'active')}">
-            <f:link.page pageUid="{item.data.uid}" title="{item.title}">
-                {item.title}
+            <f:link.page pageUid="{item.data.uid}" title="{item.title -> f:format.raw()}">
+                {item.title -> f:format.raw()}
             </f:link.page>
             <f:if condition="{item.children}">
                 <ul>


### PR DESCRIPTION
Menu titles already get escaped by TypoScript in
\BK2K\BootstrapPackage\DataProcessing\MenuProcessor. This patch ensures
the tiles are used without escaping.