### PR TITLE
Reduce http requests

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -426,10 +426,10 @@ page {
             disableCompression = 1
             excludeFromConcatenation = 1
         }
-        ionicons = EXT:bootstrap_package/Resources/Public/Css/ionicons.min.css
     }
 
     includeCSS {
+        ionicons = EXT:bootstrap_package/Resources/Public/Css/ionicons.min.css
         # bootstrap will be included in the themes.less file
         # for standalone usage just uncomment the following line
         # bootstrap = EXT:bootstrap_package/Resources/Public/Less/Bootstrap/bootstrap.less

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -436,7 +436,7 @@ page {
         theme = EXT:bootstrap_package/Resources/Public/Less/Theme/theme.less
     }
 
-    includeJSLibs {
+    includeJS {
         modernizr = EXT:bootstrap_package/Resources/Public/JavaScript/Dist/modernizr.min.js
         modernizr.forceOnTop = 1
         modernizr.async = 1


### PR DESCRIPTION
RsaEncryptionEncoder adds its JS files with addJsFile() and bootstrap_package adds its JS files with includeJSLibs. This causes to have 2 different merged JS files in the HTML code so 2 different request.
To have a single request we change the inclusion method to includeJS since includeJSLibs is not needed in this case.
