### PR TITLE
Resolve shortcut links

### DIFF
--- a/Classes/ViewHelpers/ResolveLinkViewHelper.php
+++ b/Classes/ViewHelpers/ResolveLinkViewHelper.php
@@ -1,0 +1,75 @@
+<?php
+namespace BK2K\BootstrapPackage\ViewHelpers;
+
+/*
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) 2014 Benjamin Kott, http://www.bk2k.info
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3\CMS\Frontend\Controller\TyposcriptFrontendController;
+/**
+ * @author Benjamin Kott <info@bk2k.info>
+ */
+class ResolveLinkViewHelper extends AbstractViewHelper implements CompilableInterface
+{
+
+    /**
+     * Render
+     *
+     * @param string $property
+     * @return string
+     */
+    public function render($page = null)
+    {
+        return self::renderStatic(
+            [
+                'page' => $page
+            ],
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return void
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $page = $arguments['page'];
+        if ($page['doktype'] == 4){  // PageRepository::DOKTYPE_SHORTCUT
+          $page = $GLOBALS['TSFE']->getPageShortcut($page['shortcut'], $page['shortcut_mode'], $page['uid']);
+          if ($page['hidden'] || $page['starttime'] > $GLOBALS['SIM_EXEC_TIME'] || $page['endtime'] != 0 && $page['endtime'] <= $GLOBALS['SIM_EXEC_TIME']){
+            return $arguments['page']['uid'];
+          }
+        }
+        return $page['uid'];
+    }
+}

--- a/Resources/Private/Templates/ContentElements/Menu.html
+++ b/Resources/Private/Templates/ContentElements/Menu.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -10,10 +11,10 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                   <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.page>
                 </li>
             </f:for>
         </ul>
     </f:if>
-
+    
 </f:section>

--- a/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePages.html
+++ b/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePages.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -10,7 +11,7 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                    <f:link.typolink parameter="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.typolink>
                 </li>
             </f:for>
         </ul>

--- a/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePagesAbstract.html
+++ b/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePagesAbstract.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -10,7 +11,7 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                    <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.page>
                     <f:if condition="{page.data.abstract}">
                         <f:format.html>{page.data.abstract}</f:format.html>
                     </f:if>

--- a/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePagesAndSections.html
+++ b/Resources/Private/Templates/ContentElements/MenuOfSubpagesToThesePagesAndSections.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -10,12 +11,12 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                    <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.page>
                     <f:if condition="{page.content}">
                         <ul>
                             <f:for each="{page.content}" as="element">
                                 <li>
-                                    <f:link.page pageUid="{element.data.pid}" section="{element.data.uid}">{element.data.header}</f:link.page>
+                                    <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}" section="{element.data.uid}">{element.data.header}</f:link.page>
                                 </li>
                             </f:for>
                         </ul>

--- a/Resources/Private/Templates/ContentElements/MenuSitemap.html
+++ b/Resources/Private/Templates/ContentElements/MenuSitemap.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -15,7 +16,7 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                    <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.page>
                     <f:render section="Menu" arguments="{menu: page.children}" />
                 </li>
             </f:for>

--- a/Resources/Private/Templates/ContentElements/MenuSitemapOfSelectedPages.html
+++ b/Resources/Private/Templates/ContentElements/MenuSitemapOfSelectedPages.html
@@ -1,3 +1,4 @@
+{namespace bk2k = BK2K\BootstrapPackage\ViewHelpers}
 <f:layout name="Default"/>
 <f:section name="Header">
 
@@ -15,7 +16,7 @@
         <ul>
             <f:for each="{menu}" as="page">
                 <li>
-                    <f:link.page pageUid="{page.data.uid}">{page.data.title}</f:link.page>
+                    <f:link.page pageUid="{bk2k:resolveLink(page:'{page.data}')}">{page.data.title}</f:link.page>
                     <f:render section="Menu" arguments="{menu: page.children}" />
                 </li>
             </f:for>


### PR DESCRIPTION
Hi,
Prevent server side redirection for shortcut pages by resolving links,
to fit the standard behaviour of hmenu.
Dosen't still resolve mount points.
fix issue #380