### PR TITLE
[BUGFIX] Move TCA change in ext_tables.php to TCA/Overrides

### DIFF
--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,5 @@
+<?php
+defined('TYPO3_MODE') or die();
+
+// Default TypoScript
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Bootstrap Package');

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,11 +11,6 @@ if (!is_array($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf'][$_EXTKEY])) {
 }
 
 /***************
- * Default TypoScript
- */
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile($_EXTKEY, 'Configuration/TypoScript', 'Bootstrap Package');
-
-/***************
  * Backend Styling
  */
 if (TYPO3_MODE == 'BE') {


### PR DESCRIPTION
A new core check within the install tool will soon check for extensions
that still change TCA from within ext_tables.php files.
The patch fixes the last match in ext:bootstrap_package.

Related: #78384