### PR TITLE
[TASK] remove uniqueLinkVars

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -519,7 +519,6 @@ page {
 config {
     absRefPrefix = auto
     no_cache = {$config.no_cache}
-    uniqueLinkVars = 1
     pageTitleFirst = 1
     linkVars = L
     prefixLocalAnchors = {$config.prefixLocalAnchors}


### PR DESCRIPTION
config.uniqueLinkVars has been removed in TYPO3 7.0