### PR TITLE
[BUGFIX] Fix sys_language_uid when adding item to translated tt_content

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_accordion_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_accordion_item.php
@@ -45,6 +45,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
     ],
@@ -67,6 +68,11 @@ return [
             'showitem' => '
                 hidden;LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:accordion_item
             '
+        ],
+        // hidden but needs to be included all the time, so sys_language_uid is set correctly
+        'hiddenLanguagePalette' => [
+            'showitem' => 'sys_language_uid, l10n_parent',
+            'isHiddenPalette' => true,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -60,6 +60,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
         'header' => [
@@ -74,6 +75,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
         'textandimage' => [
@@ -90,6 +92,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
         'backgroundimage' => [
@@ -101,6 +104,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
         'html' => [
@@ -114,6 +118,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
     ],
@@ -146,6 +151,11 @@ return [
             'showitem' => '
                 hidden;LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel_item
             '
+        ],
+        // hidden but needs to be included all the time, so sys_language_uid is set correctly
+        'hiddenLanguagePalette' => [
+            'showitem' => 'sys_language_uid, l10n_parent',
+            'isHiddenPalette' => true,
         ],
     ],
     'columns' => [

--- a/Configuration/TCA/tx_bootstrappackage_tab_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_tab_item.php
@@ -45,6 +45,7 @@ return [
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.visibility;visibility,
                 --palette--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:palette.access;access,
+                --palette--;;hiddenLanguagePalette,
             '
         ],
     ],
@@ -67,6 +68,11 @@ return [
             'showitem' => '
                 hidden;LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:tab_item
             '
+        ],
+        // hidden but needs to be included all the time, so sys_language_uid is set correctly
+        'hiddenLanguagePalette' => [
+            'showitem' => 'sys_language_uid, l10n_parent',
+            'isHiddenPalette' => true,
         ],
     ],
     'columns' => [


### PR DESCRIPTION


### Description
In the patch https://review.typo3.org/#/c/52061/1 TYPO3 v8 now setts correct sys_language_uid on child items, when adding them directly to translated parent (tt_content).
However this patch only works when sys_language_uid is in the showitem array.

This patch adds a hidden palette which language fields. The same solution is used in the core for FAL fields.

### Steps to Validate

1. Add tt_content with acordeon item and translate it to language 1
2. see in db that translated items will have correct sys_language_uid set (1)
3. add new item to the translated tt_content
4. check in db that sys_language_uid of the child is 0
5. apply the patch, clear cache
6. redo step 3 and 4
7. see that sys_language_uid is set correctlt to 1 
