### PR TITLE
properly separate navbar default and inverse styles

### DIFF
--- a/Resources/Public/Less/Theme/navbar.less
+++ b/Resources/Public/Less/Theme/navbar.less
@@ -51,23 +51,27 @@
     .navbar-default-transition,
     .navbar-inverse-transition {
         .transition(all 0.27s cubic-bezier(0, 0, 0.58, 1) 0s);
+    }
+    .navbar-default-transition {
         background-color: transparent;
         border-color: transparent;
-        .navbar-nav > .open,
-        .navbar-nav > .active,
-        .navbar-nav > li {
-            > a,
-            > a:hover,
-            > a:focus {
-                color: #ffffff;
-            }
-        }
+    }
+    .navbar-inverse-transition {
         .navbar-brand {
             > .navbar-brand-logo-normal {
                 display: none;
             }
             > .navbar-brand-logo-inverted {
                 display: block;
+            }
+        }
+        .navbar-nav > .open,
+        .navbar-nav > .active,
+        .navbar-nav > li, {
+            > a,
+            > a:hover,
+            > a:focus {
+                color: #ffffff;
             }
         }
     }
@@ -77,14 +81,6 @@
         .navbar-main > li > a {
             line-height: @navbar-height;
             height: @navbar-height;
-        }
-        .navbar-brand {
-            > .navbar-brand-logo-normal {
-                display: block;
-            }
-            > .navbar-brand-logo-inverted {
-                display: none;
-            }
         }
     }
 }


### PR DESCRIPTION
### Prerequisites

* [x] Changes have been tested on TYPO3 8.7 LTS
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix --config-file .php_cs`

### Description

This fixes the styles for the navbar (default and inverse) so they work like they should.

### Steps to Validate

1. install the introduction distribution
2. go to the homepage (pid=1)
3. see that the links have the wrong color (white)
4. change the class names to use the inverse styles and see that the colors and logo are wrong
