### PR TITLE
[TASK] Avoid ambiguous "uid" error

### DIFF
--- a/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
+++ b/Configuration/TypoScript/ContentElement/MenuCategorizedContent.typoscript
@@ -23,7 +23,7 @@ tt_content.menu_categorized_content {
             pidInList.data = leveluid : 0
             recursive = 99
             join.data = field:selected_categories
-            join.wrap = sys_category_record_mm ON uid = sys_category_record_mm.uid_foreign AND sys_category_record_mm.uid_local IN(|)
+            join.wrap = sys_category_record_mm ON tt_content.uid = sys_category_record_mm.uid_foreign AND sys_category_record_mm.uid_local IN(|)
             where.data = field:category_field
             where.wrap = tablenames='tt_content' and fieldname='|'
             as = content


### PR DESCRIPTION
If the table "sys_category_record_mm" is promoted to a 1st level table and gets a "uid" column, the menu "Content elements for selected categories" will throw an SQL error like this:

> Column 'uid' in on clause is ambiguous

Avoid this by explicitly prefixing the table name.

Fixes # .

### Prerequisites

* [ ] Changes have been tested on TYPO3 8.7 LTS
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix --config-file .php_cs`

### Description

[Description of changes proposed in this pull request]

### Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
