### PR TITLE
Wrong option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@ Fixes # .
 ### Prerequisites
 
 * [ ] Changes have been tested on TYPO3 8.7 LTS
-* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix --config-file .php_cs`
+* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
 
 ### Description
 


### PR DESCRIPTION
### Description

Using `--config-file` option returns errors, without everything is ok inclusive loading of the default config:

  The "--config-file" option does not exist.


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--diff-format DIFF-FORMAT] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>]...
