### PR TITLE
[!!!][TASK] Use typoscript instead of txt file extension

### DIFF
--- a/Configuration/TypoScript/Extension/Form.typoscript
+++ b/Configuration/TypoScript/Extension/Form.typoscript
@@ -3,5 +3,5 @@
 ###############################
 
 [userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')]
-    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:form/Configuration/TypoScript/setup.txt">
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:form/Configuration/TypoScript/setup.typoscript">
 [global]

--- a/Configuration/TypoScript/Extension/IndexedSearch.typoscript
+++ b/Configuration/TypoScript/Extension/IndexedSearch.typoscript
@@ -3,7 +3,7 @@
 ########################
 
 [userFunc = TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('indexed_search')]
-    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:indexed_search/Configuration/TypoScript/setup.txt">
+    <INCLUDE_TYPOSCRIPT: source="FILE:EXT:indexed_search/Configuration/TypoScript/setup.typoscript">
     plugin.tx_indexedsearch {
         view {
             templateRootPaths {


### PR DESCRIPTION
This change makes ext:bootstrap_package incompatible to TYPO3 v8.

Fixes #529