### PR TITLE
[BUGFIX] Correct primary label in bs4 typoscript constants

### DIFF
--- a/Configuration/TypoScript/Bootstrap4/constants.typoscript
+++ b/Configuration/TypoScript/Bootstrap4/constants.typoscript
@@ -89,7 +89,7 @@ plugin.bootstrap_package {
             cyan = #17a2b8
             # cat=bootstrap 4.x: styling/300/default; type=string; label=$default:
             default = #eaebec
-            # cat=bootstrap 4.x: styling/300/secondary; type=string; label=$secondary:
+            # cat=bootstrap 4.x: styling/300/secondary; type=string; label=$primary:
             primary = #4faf98
             # cat=bootstrap 4.x: styling/300/secondary; type=string; label=$secondary:
             secondary = #ff3f00

--- a/Configuration/TypoScript/Bootstrap4/constants.typoscript
+++ b/Configuration/TypoScript/Bootstrap4/constants.typoscript
@@ -89,7 +89,7 @@ plugin.bootstrap_package {
             cyan = #17a2b8
             # cat=bootstrap 4.x: styling/300/default; type=string; label=$default:
             default = #eaebec
-            # cat=bootstrap 4.x: styling/300/secondary; type=string; label=$primary:
+            # cat=bootstrap 4.x: styling/300/primary; type=string; label=$primary:
             primary = #4faf98
             # cat=bootstrap 4.x: styling/300/secondary; type=string; label=$secondary:
             secondary = #ff3f00


### PR DESCRIPTION
FIX wrong TS constant label.

### Prerequisites

* [ ] Changes have been tested on TYPO3 8.7 LTS
* [X ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

The label for constant $primary is wrong ($secondary). This MR fixes that.

### Steps to Validate
You can see this in constant editor.
