### PR TITLE
wrong htmlSpecialChars with lib.stdheader

### DIFF
--- a/Configuration/ContentElements/Base.ts
+++ b/Configuration/ContentElements/Base.ts
@@ -201,7 +201,7 @@ lib.stdheader {
             20 = TEXT
             20 {
                 field = subheader
-                htmlSpecialChars = 1
+                stdWrap.htmlSpecialChars = 1
                 stdWrap.noTrimWrap = | <small>|</small>|
                 stdWrap.required = 1
             }


### PR DESCRIPTION
the html escaping should not affect the <small> tags. Therefor it needs to be applied on the "inner" wrapping i.e. noTrimWrap. #368 #404 @IchHabRecht 
