### PR TITLE
[BUGFIX] use correct default value for texticon icon type

### DIFF
--- a/Configuration/TCA/Overrides/225_content_element_texticon.php
+++ b/Configuration/TCA/Overrides/225_content_element_texticon.php
@@ -199,7 +199,7 @@ $GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
             'config' => [
                 'type' => 'select',
                 'renderType' => 'selectSingle',
-                'default' => '0',
+                'default' => 'default',
                 'items' => [
                     ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.default', 'default'],
                     ['LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.square', 'square'],


### PR DESCRIPTION
Fixes wrong icon type default value in content element texticon.

### Prerequisites

* [x ] Changes have been tested on TYPO3 8.7 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
