### PR TITLE
Keep custom layout values when updating Carousel CEs

### DIFF
--- a/Classes/Updates/CarouselContentElementUpdate.php
+++ b/Classes/Updates/CarouselContentElementUpdate.php
@@ -72,8 +72,10 @@ class CarouselContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUp
                         $queryBuilder->createNamedParameter($record['uid'], \PDO::PARAM_INT)
                     )
                 )
-                ->set('layout', 0, false)
                 ->set('CType', $this->mapValues($record['layout']));
+            if (in_array($record['layout'], [100, 110, 120])) {
+                $queryBuilder->set('layout', 0, false);
+            }
             $databaseQueries[] = $queryBuilder->getSQL();
             $queryBuilder->execute();
         }


### PR DESCRIPTION
Fixes #568 .

### Prerequisites

* [x] Changes have been tested on TYPO3 8.7 LTS
* [ ] Changes have been tested on TYPO3 dev-master (not applicable?)
* [x] Changes have been tested on PHP 7.0.x
* [x] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

The layout field of carousel content elements is changed to 0 **only if** its previous value equals 100, 110 or 120.

### Steps to Validate

see issue #568