### PR TITLE
[FEATURE] Make cookieconsent content configurable

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -124,23 +124,35 @@ page {
             # cat=bootstrap package: cookie consent/230/04_static; type=boolean; label=Static Position: The popup uses position fixed to stay in one place on the screen despite any scroll bars. This option makes the popup position static so it displays at the top of the page. A height animation has also been added by default so the popup doesn’t make the page jump, but gradually grows and fades in.
             static = 0
             content {
-                # cat=bootstrap package: cookie consent/230/05_content_href; type=string; label=Privacy Police: Insert a full Link to the privacy police page or a page uid from your current TYPO3 System.
-                href =
+                # cat=bootstrap package: cookie consent/230/05_content_header; type=string; label=Header Content: Text string used for the header.
+                header = Cookies used on the website!
+                # cat=bootstrap package: cookie consent/230/06_content_message; type=string; label=Message Content: Text string used for the message.
+                message = This website uses cookies to ensure you get the best experience on our website.
+                # cat=bootstrap package: cookie consent/230/07_content_dismiss; type=string; label=Dismiss Content: Text string used for the dismiss button.
+                dismiss = Got it!
+                # cat=bootstrap package: cookie consent/230/08_content_allow; type=string; label=Allow Content: Text string used for the allow button.
+                allow = Allow cookies
+                # cat=bootstrap package: cookie consent/230/09_content_deny; type=string; label=Deny Content: Text string used for the deny button.
+                deny = Decline
+                # cat=bootstrap package: cookie consent/230/10_content_link; type=string; label=Link Content: Text string used for the link to the privacy police page.
+                link = Learn more
+                # cat=bootstrap package: cookie consent/230/11_content_href; type=string; label=Privacy Police: Insert a full Link to the privacy police page or a page uid from your current TYPO3 System.
+                href =                
             }
-            # cat=bootstrap package: cookie consent/230/06_revokable; type=boolean; label=Revokable: If set true, revoke button is displayed every time. If false, revoke button is only displayed for advanced compliance options (opt-in and opt-out) and in countries that require revokable consent. The latter can be disabled by regionalLaw.
+            # cat=bootstrap package: cookie consent/230/12_revokable; type=boolean; label=Revokable: If set true, revoke button is displayed every time. If false, revoke button is only displayed for advanced compliance options (opt-in and opt-out) and in countries that require revokable consent. The latter can be disabled by regionalLaw.
             revokable = 0
-            # cat=bootstrap package: cookie consent/230/07_location; type=boolean; label=Location Detection: Location is simply a tool for getting the two letter country code that the user is in.
+            # cat=bootstrap package: cookie consent/230/13_location; type=boolean; label=Location Detection: Location is simply a tool for getting the two letter country code that the user is in.
             location = 0
             law {
-                # cat=bootstrap package: cookie consent/230/08_law_countryCode; type=string; label=Country Code: Rather than getting the country code from the location services, you can hard code a particular country into the tool.
+                # cat=bootstrap package: cookie consent/230/14_law_countryCode; type=string; label=Country Code: Rather than getting the country code from the location services, you can hard code a particular country into the tool.
                 countryCode =
-                # cat=bootstrap package: cookie consent/230/09_law_regionalLaw; type=boolean; label=Regional Law: If false, then we only enable the popup if the country has the cookie law. We ignore all other country specific rules.
+                # cat=bootstrap package: cookie consent/230/15_law_regionalLaw; type=boolean; label=Regional Law: If false, then we only enable the popup if the country has the cookie law. We ignore all other country specific rules.
                 regionalLaw = 1
             }
-            # cat=bootstrap package: cookie consent/230/10_type; type=options[Informal=info, Opt-In=opt-in, Opt-Out=opt-out]; label=Compliance: The informal confirmation does not require any further adjustments to your JavaScript. The Opt-In and Opt-Out options are not out-of-the-box solutions, manual adjustments to your software are necessary. For your support we provide the events bk2k.cookie.enable, bk2k.cookie.disable and bk2k.cookie.revoke. These events allow you to let your application react to them and to set or remove cookies accordingly. The cookie that contains the current status is called cookieconsent_status.
+            # cat=bootstrap package: cookie consent/230/16_type; type=options[Informal=info, Opt-In=opt-in, Opt-Out=opt-out]; label=Compliance: The informal confirmation does not require any further adjustments to your JavaScript. The Opt-In and Opt-Out options are not out-of-the-box solutions, manual adjustments to your software are necessary. For your support we provide the events bk2k.cookie.enable, bk2k.cookie.disable and bk2k.cookie.revoke. These events allow you to let your application react to them and to set or remove cookies accordingly. The cookie that contains the current status is called cookieconsent_status.
             type = info
             cookie {
-                # cat=bootstrap package: cookie consent/230/11_expiryDays; type=int; label=Expiry Days: The cookies expire date, specified in days (specify -1 for no expiry)
+                # cat=bootstrap package: cookie consent/230/17_expiryDays; type=int; label=Expiry Days: The cookies expire date, specified in days (specify -1 for no expiry)
                 expiryDays = 365
             }
         }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -91,25 +91,6 @@
                 <source>Summary</source>
             </trans-unit>
 
-            <trans-unit id="cookieconsent.common.header">
-                <source>Cookies used on the website!</source>
-            </trans-unit>
-            <trans-unit id="cookieconsent.common.message">
-                <source>This website uses cookies to ensure you get the best experience on our website.</source>
-            </trans-unit>
-            <trans-unit id="cookieconsent.common.dismiss">
-                <source>Got it!</source>
-            </trans-unit>
-            <trans-unit id="cookieconsent.common.allow">
-                <source>Allow cookies</source>
-            </trans-unit>
-            <trans-unit id="cookieconsent.common.deny">
-                <source>Decline</source>
-            </trans-unit>
-            <trans-unit id="cookieconsent.common.link">
-                <source>Learn more</source>
-            </trans-unit>
-
             <trans-unit id="googleanalyticsstatus.title">
                 <source>Google Analytics Status</source>
             </trans-unit>

--- a/Resources/Private/Partials/Page/Structure/CookieConsent.html
+++ b/Resources/Private/Partials/Page/Structure/CookieConsent.html
@@ -2,12 +2,12 @@
 <f:if condition="{theme.cookieconsent.enable}">
 <div id="cookieconsent">
     <span data-cookieconsent-setting="cookie.expiryDays" data-cookieconsent-value="{theme.cookieconsent.cookie.expiryDays}"></span>
-    <span data-cookieconsent-setting="content.header" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.header',extensionName:'bootstrap_package')}"></span>
-    <span data-cookieconsent-setting="content.message" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.message',extensionName:'bootstrap_package')}"></span>
-    <span data-cookieconsent-setting="content.dismiss" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.dismiss',extensionName:'bootstrap_package')}"></span>
-    <span data-cookieconsent-setting="content.allow" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.allow',extensionName:'bootstrap_package')}"></span>
-    <span data-cookieconsent-setting="content.deny" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.deny',extensionName:'bootstrap_package')}"></span>
-    <span data-cookieconsent-setting="content.link" data-cookieconsent-value="{f:translate(key:'cookieconsent.common.link',extensionName:'bootstrap_package')}"></span>
+    <span data-cookieconsent-setting="content.header" data-cookieconsent-value="{theme.cookieconsent.content.header}"></span>
+    <span data-cookieconsent-setting="content.message" data-cookieconsent-value="{theme.cookieconsent.content.message}"></span>
+    <span data-cookieconsent-setting="content.dismiss" data-cookieconsent-value="{theme.cookieconsent.content.dismiss}"></span>
+    <span data-cookieconsent-setting="content.allow" data-cookieconsent-value="{theme.cookieconsent.content.allow}"></span>
+    <span data-cookieconsent-setting="content.deny" data-cookieconsent-value="{theme.cookieconsent.content.deny}"></span>
+    <span data-cookieconsent-setting="content.link" data-cookieconsent-value="{theme.cookieconsent.content.link}"></span>
     <span data-cookieconsent-setting="content.href" data-cookieconsent-value="{f:uri.page(pageUid: theme.cookieconsent.content.href)}"></span>
     <span data-cookieconsent-setting="layout" data-cookieconsent-value="{theme.cookieconsent.layout}"></span>
     <span data-cookieconsent-setting="type" data-cookieconsent-value="{theme.cookieconsent.type}"></span>


### PR DESCRIPTION
Make the cookie consent content text strings configurable.

### Prerequisites

* [x] Changes have been tested on TYPO3 8.7 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

The translation for the cookie consent content text strings are missing since release of version 10.0. 
With this PR the cookie consent content text strings are configurable in the constant editor.
