### PR TITLE
[FEATURE] Collapsible in accordion should scroll to the top of content

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -407,6 +407,7 @@ page {
         photoswipe_ui = EXT:bootstrap_package/Resources/Public/Contrib/photoswipe/photoswipe-ui-default.min.js
 
         #### Custom Modules
+        bootstrap_accordion = EXT:bootstrap_package/Resources/Public/JavaScript/Dist/bootstrap.accordion.min.js
         bootstrap_form = EXT:bootstrap_package/Resources/Public/JavaScript/Dist/bootstrap.form.min.js
         bootstrap_swipe = EXT:bootstrap_package/Resources/Public/JavaScript/Dist/bootstrap.swipe.min.js
         bootstrap_popover = EXT:bootstrap_package/Resources/Public/JavaScript/Dist/bootstrap.popover.min.js

--- a/Resources/Public/JavaScript/Dist/bootstrap.accordion.min.js
+++ b/Resources/Public/JavaScript/Dist/bootstrap.accordion.min.js
@@ -1,0 +1,1 @@
+$(".accordion").on("hide.bs.collapse",function(o){var a=$(o.target).prev(".accordion-header").offset().top-5;a<$(window).scrollTop()&&$("html,body").animate({scrollTop:a},500)});

--- a/Resources/Public/JavaScript/Src/bootstrap.accordion.js
+++ b/Resources/Public/JavaScript/Src/bootstrap.accordion.js
@@ -1,0 +1,12 @@
+/**
+ * Scroll to top of collapsed/expanded accordion item
+ */
+$('.accordion').on('hide.bs.collapse', function (e) {
+    var headingTop = $(e.target).prev('.accordion-header').offset().top - 5;
+    var visibleTop = $(window).scrollTop();
+    if (headingTop < visibleTop) {
+        $('html,body').animate({
+            scrollTop: headingTop
+        }, 500);
+    }
+});


### PR DESCRIPTION
Fixes #588 .

### Prerequisites

* [ ] Changes have been tested on TYPO3 8.7 LTS
* [x] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Add custom javascript to calulate position of expanded accordion entry.
This lets the window scroll to top of its content, when not in focus.

### Steps to Validate

1. Create accordion content element with at least 2 entries, where the first entry has long text as content and second entry just a short content.
2. Open page with accordion, and open first entry
3. Scroll down and open second entry
4. Second accordion entry should scroll to top of window, so its content is visible at start
