### PR TITLE
Add og:url to typoscript

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -334,6 +334,12 @@ page {
             attribute = property
             field = description
         }
+        og:url = TEXT
+        og:url {
+            typolink.parameter.data = TSFE:id
+            typolink.forceAbsoluteUrl = 1
+            typolink.returnLast = url
+        }
         og:image {
             attribute = property
             stdWrap.cObject = FILES


### PR DESCRIPTION
Add the og:url meta tag filled with the page url
I´m not really sure if its needed - if not, just delete the pull request.

* [x] Changes have been tested on TYPO3 8.7 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [x] Changes have been tested on PHP 7.0.x
* [x] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Add the OG:URL to the page

### Steps to Validate

1. Open page in frontend
2. view sourcecode
3. search for <meta name="og:url" content=".....URL....">
