### PR TITLE
[FEATURE] Show alternative title of a page not title of a page.

### DIFF
--- a/Resources/Private/Templates/ContentElements/MenuCardDir.html
+++ b/Resources/Private/Templates/ContentElements/MenuCardDir.html
@@ -33,8 +33,8 @@
                             </f:if>
                             <f:if condition="{page.title}">
                                 <h3 class="card-title">
-                                    <a href="{page.link}"{f:if(condition: page.target, then: ' target="{page.target}"')} title="{page.title}" data-toggle="tooltip">
-                                        <f:format.crop maxCharacters="{settings.menucard.title.crop}">{page.title}</f:format.crop>
+                                    <a href="{page.link}"{f:if(condition: page.target, then: ' target="{page.target}"')} title="{page.nav_title -> f:or(alternative:'{page.nav_title}')}" data-toggle="tooltip">
+                                        <f:format.crop maxCharacters="{settings.menucard.title.crop}">{page.nav_title -> f:or(alternative:'{page.nav_title}')}</f:format.crop>
                                     </a>
                                 </h3>
                             </f:if>
@@ -48,7 +48,7 @@
                             </f:if>
                         </div>
                         <div class="card-footer">
-                            <a href="{page.link}"{f:if(condition: page.target, then: ' target="{page.target}"')} class="card-link" title="{page.title}" data-toggle="tooltip">
+                            <a href="{page.link}"{f:if(condition: page.target, then: ' target="{page.target}"')} class="card-link" title="{page.nav_title -> f:or(alternative:'{page.nav_title}')}" data-toggle="tooltip">
                                 <f:if condition="{data.readmore_label}">
                                     <f:then>
                                         {data.readmore_label}


### PR DESCRIPTION
Sometimes and somewhere I want to show nav_title and not title,.. in currently it is not possible is need to do custom changes.

Show alternative title of a page not title of a page. If `page.nav_title` empty, then show `page.title` if not then show `page.nav_title`

### Prerequisites

* [x] Changes have been tested on TYPO3 v9.5 LTS
