### PR TITLE
[BUGFIX] Override the fields keywords and author

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -301,13 +301,21 @@ page {
         description {
             override.field = description
         }
-        author = {$page.meta.author}
-        author {
-            override.field = author
-        }
         keywords = {$page.meta.keywords}
         keywords {
-            override.field = keywords
+            stdWrap {
+                override {
+                    data = page:keywords
+                }
+            }
+        }
+        author = {$page.meta.author}
+        author {
+            stdWrap {
+                override {
+                    data = page:author
+                }
+            }
         }
         X-UA-Compatible = {$page.meta.compatible}
         X-UA-Compatible {


### PR DESCRIPTION
Look at this, please.
https://forge.typo3.org/issues/86956
and
https://forge.typo3.org/issues/86234

Fixes # .

### Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on PHP 7.2.x

### Description
the override value is not rendered in the `Frontend` if it is set in the `Backend`.
Line 306  - `override.field = keywords` and line 310 - `override.field = author` -  not working

[Description of changes proposed in this pull request]
Tested on the TYPO3 v. 9.5.1 with Bootstrap Package 10.0.4 - working
```
    meta {
        keywords = {$page.meta.keywords}
        keywords {
            stdWrap {
                override {
                    data = page:keywords
                }
            }
        }
        author = {$page.meta.author}
        author {
            stdWrap {
                override {
                    data = page:author
                }
            }
        }
    }
```
