### PR TITLE
[BUGFIX] Make Less Parser PHP 7.3 compatible

### DIFF
--- a/Contrib/less.php/Less.php
+++ b/Contrib/less.php/Less.php
@@ -9706,7 +9706,7 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 				case 40:
 					$parenLevel++;
 					$lastParen = $this->parserCurrentIndex;
-					continue;
+                    continue 2;
 
 				// )
 				case 41:
@@ -9714,18 +9714,18 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 					if( $parenLevel < 0 ){
 						return $this->fail("missing opening `(`");
 					}
-					continue;
+                    continue 2;
 
 				// ;
 				case 59:
 					//if (!$parenLevel) { $this->emitChunk();	}
-					continue;
+                    continue 2;
 
 				// {
 				case 123:
 					$level++;
 					$lastOpening = $this->parserCurrentIndex;
-					continue;
+                    continue 2;
 
 				// }
 				case 125:
@@ -9735,10 +9735,12 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 
 					}
 					//if (!$level && !$parenLevel) { $this->emitChunk(); }
-					continue;
+                    continue 2;
 				// \
 				case 92:
-					if ($this->parserCurrentIndex < $this->input_len - 1) { $this->parserCurrentIndex++; continue; }
+					if ($this->parserCurrentIndex < $this->input_len - 1) { $this->parserCurrentIndex++;
+                        continue 2;
+                    }
 					return $this->fail("unescaped `\\`");
 
 				// ", ' and `
@@ -9758,12 +9760,16 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 							$this->parserCurrentIndex++;
 						}
 					}
-					if ($matched) { continue; }
+					if ($matched) {
+                        continue 2;
+                    }
 					return $this->fail("unmatched `" . chr($cc) . "`", $currentChunkStartIndex);
 
 				// /, check for comment
 				case 47:
-					if ($parenLevel || ($this->parserCurrentIndex == $this->input_len - 1)) { continue; }
+					if ($parenLevel || ($this->parserCurrentIndex == $this->input_len - 1)) {
+                        continue 2;
+                    }
 					$cc2 = $this->CharCode($this->parserCurrentIndex+1);
 					if ($cc2 == 47) {
 						// //, find lnfeed
@@ -9784,14 +9790,14 @@ class Less_Exception_Chunk extends Less_Exception_Parser{
 							return $this->fail("missing closing `*/`", $currentChunkStartIndex);
 						}
 					}
-					continue;
+                    continue 2;
 
 				// *, check for unmatched */
 				case 42:
 					if (($this->parserCurrentIndex < $this->input_len - 1) && ($this->CharCode($this->parserCurrentIndex+1) == 47)) {
 						return $this->fail("unmatched `/*`");
 					}
-					continue;
+                    continue 2;
 			}
 		}
 


### PR DESCRIPTION
Fixes: #584

### Prerequisites

* [x] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [x] Changes have been tested on PHP 7.3.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Replace `continue` with `continue 2` in less parser.

### Steps to Validate

1. Install PHP 7.3
2. View Less Version of BP
3. Apply Patch: no more error.
