### PR TITLE
[BUGFIX] ce uploads accepts sorting direction

### DIFF
--- a/Configuration/TypoScript/ContentElement/Element/Uploads.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/Uploads.typoscript
@@ -20,6 +20,7 @@ tt_content.uploads {
             references.fieldName = media
             collections.field = file_collections
             sorting.field = filelink_sorting
+            sorting.direction.field = filelink_sorting_direction
         }
     }
 


### PR DESCRIPTION
### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

When creating a content element "File Links" [uploads] specifying the sorting direction desc is ignored.