### PR TITLE
Make site header full-width if necessary.

### DIFF
--- a/Configuration/TypoScript/constants.typoscript
+++ b/Configuration/TypoScript/constants.typoscript
@@ -60,6 +60,11 @@ page {
             weight = 300,400,700
         }
 
+        header {
+            # cat=bootstrap package: header/171/1_wide; type=boolean; label=Enable full width header
+            wide = false
+        }
+
         navigation {
             # cat=bootstrap package: navigation/151/100; type=options[Default=default, Default Transition=default-transition, Inverse=inverse, Inverse Transition=inverse-transition]; label=Navigation Style
             style = default

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -228,7 +228,11 @@ page {
                 width = {$page.logo.width}
                 linktitle = {$page.logo.linktitle}
             }
+            header {
+                wide = {$page.theme.header.wide}
+            }
         }
+
 
         #################
         ### VARIABLES ###

--- a/Resources/Private/Partials/Page/Navigation/Main.html
+++ b/Resources/Private/Partials/Page/Navigation/Main.html
@@ -1,7 +1,8 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
 
 <header id="page-header" class="bp-page-header navbar navbar-mainnavigation navbar-{theme.navigation.style}{f:if(condition:settings.logo.file,then:' navbar-has-image')}{f:if(condition:theme.navigation.type, else:' navbar-top', then:' navbar-{theme.navigation.type} navbar-fixed-{theme.navigation.type}')}">
-    <div class="container">
+    <div class="{f:if(condition:settings.header.wide, then:'container-fluid', else:'container')}">
+
         <f:if condition="{settings.logo.file}">
             <f:then>
                 <f:link.page pageUid="{rootPage}" class="navbar-brand navbar-brand-image" title="{settings.logo.linktitle}">


### PR DESCRIPTION

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [ X] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [X ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Added a configuration to make header full-width without overriding templates.

### Steps to Validate

1. Clear cache. The header should remain compact width for backward compatibility.
2. Change constant page.theme.header.wide=1. Clear cache. The header will be full width.
