### PR TITLE
Fix typo in main menu template

### DIFF
--- a/Resources/Private/Partials/Page/Navigation/Main.html
+++ b/Resources/Private/Partials/Page/Navigation/Main.html
@@ -37,8 +37,8 @@
             <f:for each="{menu}" as="item">
                 <f:if condition="{item.spacer}">
                     <f:then>
-                        </ul>
                         <ul class="navbar-nav">
+                        </ul>
                     </f:then>
                     <f:else>
                         <li class="nav-item{f:if(condition: item.active, then:' active')}{f:if(condition: item.children, then:' dropdown dropdown-hover')}">


### PR DESCRIPTION
Fixes # .

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Fix typo in html of main menu

