### PR TITLE
[TASK] Remove PHP 7.0 from Prerequisites

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,6 @@ Fixes # .
 * [ ] Changes have been tested on TYPO3 v8.7 LTS
 * [ ] Changes have been tested on TYPO3 v9.5 LTS
 * [ ] Changes have been tested on TYPO3 dev-master
-* [ ] Changes have been tested on PHP 7.0.x
 * [ ] Changes have been tested on PHP 7.1.x
 * [ ] Changes have been tested on PHP 7.2.x
 * [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`


### PR DESCRIPTION
Fixes # .

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

[Description of changes proposed in this pull request]

### Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
