### PR TITLE
[FEATURE] Allow processing of configured file types

### DIFF
--- a/Classes/ViewHelpers/File/IsAudioViewHelper.php
+++ b/Classes/ViewHelpers/File/IsAudioViewHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\ViewHelpers\File;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+class IsAudioViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $file = $renderChildrenClosure();
+        $allowedFileExtensions = $GLOBALS['TYPO3_CONF_VARS']['SYS']['audiofile_ext'] ?? '';
+        $allowedFileExtensions = GeneralUtility::trimExplode(',', $allowedFileExtensions);
+
+        if (is_object($file)
+            && in_array(get_class($file), [FileReference::class, File::class], true)
+            && (
+                in_array($file->getExtension(), $allowedFileExtensions, true)
+                || $file->getType() === File::FILETYPE_AUDIO
+            )
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Classes/ViewHelpers/File/IsImageViewHelper.php
+++ b/Classes/ViewHelpers/File/IsImageViewHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\ViewHelpers\File;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+class IsImageViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $file = $renderChildrenClosure();
+        $allowedFileExtensions = $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext'] ?? '';
+        $allowedFileExtensions = GeneralUtility::trimExplode(',', $allowedFileExtensions);
+
+        if (is_object($file)
+            && in_array(get_class($file), [FileReference::class, File::class], true)
+            && (
+                in_array($file->getExtension(), $allowedFileExtensions, true)
+                || $file->getType() === File::FILETYPE_IMAGE
+            )
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Classes/ViewHelpers/File/IsMediaViewHelper.php
+++ b/Classes/ViewHelpers/File/IsMediaViewHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\ViewHelpers\File;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+class IsMediaViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * @param array $arguments
+     * @param \Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return mixed
+     */
+    public static function renderStatic(
+        array $arguments,
+        \Closure $renderChildrenClosure,
+        RenderingContextInterface $renderingContext
+    ) {
+        $file = $renderChildrenClosure();
+        $allowedFileExtensions = $GLOBALS['TYPO3_CONF_VARS']['SYS']['mediafile_ext'] ?? '';
+        $allowedFileExtensions = GeneralUtility::trimExplode(',', $allowedFileExtensions);
+
+        if (is_object($file)
+            && in_array(get_class($file), [FileReference::class, File::class], true)
+            && (
+                in_array($file->getExtension(), $allowedFileExtensions, true)
+                || $file->getType() === File::FILETYPE_VIDEO
+            )
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Resources/Private/Partials/ContentElements/Media/Type.html
+++ b/Resources/Private/Partials/ContentElements/Media/Type.html
@@ -1,12 +1,12 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:switch expression="{file.properties.type}">
-    <f:case value="2">
+<f:switch expression="1">
+    <f:case value="{file -> bk2k:file.isImage()}">
         <f:render partial="Media/Type/Image" arguments="{file: file, data: data, settings: settings, variants: variants}" />
     </f:case>
-    <f:case value="3">
+    <f:case value="{file -> bk2k:file.isAudio()}">
         <f:render partial="Media/Type/Audio" arguments="{file: file, data: data, settings: settings}" />
     </f:case>
-    <f:case value="4">
+    <f:case value="{file -> bk2k:file.isMedia()}">
         <f:render partial="Media/Type/Video" arguments="{file: file, data: data, settings: settings}" />
     </f:case>
     <f:defaultCase>

--- a/Resources/Private/Templates/ContentElements/Audio.html
+++ b/Resources/Private/Templates/ContentElements/Audio.html
@@ -5,7 +5,7 @@
     <f:if condition="{files}">
         <ul class="media-list">
             <f:for each="{files}" as="file">
-                <f:if condition="{file.properties.type} == 3">
+                <f:if condition="{file -> bk2k:file.isAudio()}">
                     <li class="media">
                         <div class="media-body">
                             <h4 class="media-heading">

--- a/Resources/Private/Templates/ContentElements/Uploads.html
+++ b/Resources/Private/Templates/ContentElements/Uploads.html
@@ -7,7 +7,7 @@
             <f:for each="{files}" as="file" iteration="fileIterator">
                 <li class="media">
                     <f:if condition="{data.uploads_type} == 2">
-                        <f:if condition="{file.type} == 2 || {file.type} == 4">
+                        <f:if condition="{file -> bk2k:file.isImage()} || {file -> bk2k:file.isMedia()}">
                             <f:if condition="{f:uri.image(src: 'file:{f:if(condition: file.originalFile, then: \'file:{file.originalFile.uid}\', else: \'file:{file.uid}\')}')} != '/'">
                                 <div class="media-left">
                                     <a href="{file.publicUrl}"{f:if(condition: file.properties.title, then: ' title="{file.properties.title}"')}{f:if(condition: data.target, then: ' target="{data.target}"')}>


### PR DESCRIPTION
To deliver the best results possible, the bootstrap package
has a strict type checking before passing assets to the 
renderings. Even if your system was capable of rendering 
images from PDFs it was not allowed by default through 
those type checkings, since a PDF is in the mime-type 
group application. 

That means we were not able to simply allow these application 
group since that would also, mean that the system would try to 
generate an image from a zip file, like in fluid styled content.

Since there is still a huge demand for PDF previews, we made 
the decision to extend the current type checks. TYPO3 allows 
to configure imagefile_ext and mediafile_ext in its configuration. 
We are now also allowing the processing of files with extensions 
configured in the according to lists.

Fixes: #647
Fixes: #576