### PR TITLE
[BUGFIX] Make UpgradeWizards repeatable

### DIFF
--- a/Classes/Updates/AccordionContentElementUpdate.php
+++ b/Classes/Updates/AccordionContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * AccordionContentElementUpdate
  */
-class AccordionContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class AccordionContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/AccordionMediaOrientUpdate.php
+++ b/Classes/Updates/AccordionMediaOrientUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * AccordionMediaOrientUpdate
  */
-class AccordionMediaOrientUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class AccordionMediaOrientUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/BackendLayoutUpdate.php
+++ b/Classes/Updates/BackendLayoutUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * BackendLayoutUpdate
  */
-class BackendLayoutUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class BackendLayoutUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/BulletContentElementUpdate.php
+++ b/Classes/Updates/BulletContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * BulletContentElementUpdate
  */
-class BulletContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class BulletContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/CarouselContentElementUpdate.php
+++ b/Classes/Updates/CarouselContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * CarouselContentElementUpdate
  */
-class CarouselContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class CarouselContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/CarouselItemTypeUpdate.php
+++ b/Classes/Updates/CarouselItemTypeUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * CarouselItemTypeUpdate
  */
-class CarouselItemTypeUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class CarouselItemTypeUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/ExternalMediaContentElement.php
+++ b/Classes/Updates/ExternalMediaContentElement.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * ExternalMediaContentElement
  */
-class ExternalMediaContentElement extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class ExternalMediaContentElement extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/ForcedUpdate.php
+++ b/Classes/Updates/ForcedUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Forces inherited classes to be executed on every update request and ignores
  * the registry state therefor.
  */
-class ForcedUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+abstract class ForcedUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
 {
     /**
      * Constructor

--- a/Classes/Updates/ForcedUpdate.php
+++ b/Classes/Updates/ForcedUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Forces inherited classes to be executed on every update request and ignores
  * the registry state therefor.
  */
-class ForcedUpdate extends ForcedUpdate
+class ForcedUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
 {
     /**
      * Constructor

--- a/Classes/Updates/ForcedUpdate.php
+++ b/Classes/Updates/ForcedUpdate.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Updates;
+
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Forces inherited classes to be executed on every update request and ignores
+ * the registry state therefor.
+ */
+class ForcedUpdate extends ForcedUpdate
+{
+    /**
+     * Constructor
+     */
+    public function __construct()
+    {
+        GeneralUtility::makeInstance(Registry::class)->set('installUpdate', get_class($this), false);
+    }
+}

--- a/Classes/Updates/FrameClassToBackgroundUpdate.php
+++ b/Classes/Updates/FrameClassToBackgroundUpdate.php
@@ -18,7 +18,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * FrameClassToBackgroundUpdate
  */
-class FrameClassToBackgroundUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class FrameClassToBackgroundUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/ListGroupContentElement.php
+++ b/Classes/Updates/ListGroupContentElement.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * ListGroupContentElement
  */
-class ListGroupContentElement extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class ListGroupContentElement extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/PanelContentElementUpdate.php
+++ b/Classes/Updates/PanelContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * PanelContentElementUpdate
  */
-class PanelContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class PanelContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TabContentElementUpdate.php
+++ b/Classes/Updates/TabContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TabContentElementUpdate
  */
-class TabContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TabContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TabMediaOrientUpdate.php
+++ b/Classes/Updates/TabMediaOrientUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TabMediaOrientUpdate
  */
-class TabMediaOrientUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TabMediaOrientUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TableContentElementUpdate.php
+++ b/Classes/Updates/TableContentElementUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TableContentElementUpdate
  */
-class TableContentElementUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TableContentElementUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TexticonContentElement.php
+++ b/Classes/Updates/TexticonContentElement.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TexticonContentElement
  */
-class TexticonContentElement extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TexticonContentElement extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TexticonIconUpdate.php
+++ b/Classes/Updates/TexticonIconUpdate.php
@@ -16,7 +16,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TexticonIconUpdate
  */
-class TexticonIconUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TexticonIconUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TexticonSizeUpdate.php
+++ b/Classes/Updates/TexticonSizeUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TexticonSizeUpdate
  */
-class TexticonSizeUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TexticonSizeUpdate extends ForcedUpdate
 {
     /**
      * @var string

--- a/Classes/Updates/TexticonTypeUpdate.php
+++ b/Classes/Updates/TexticonTypeUpdate.php
@@ -17,7 +17,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 /**
  * TexticonTypeUpdate
  */
-class TexticonTypeUpdate extends \TYPO3\CMS\Install\Updates\AbstractUpdate
+class TexticonTypeUpdate extends ForcedUpdate
 {
     /**
      * @var string


### PR DESCRIPTION
Fixes #719

Backport for TYPO3 8.7 compatibility

### Prerequisites

* [x] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on PHP 7.0.x
* [x] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

This PR is not applicable for TYPO3 master, an other aproach will be used there see #720 