### PR TITLE
BUGFIX: Fix icon size after constant change

### DIFF
--- a/Resources/Public/Scss/Theme/_texticon.scss
+++ b/Resources/Public/Scss/Theme/_texticon.scss
@@ -12,8 +12,8 @@
         text-align: center;
         margin: 0 auto;
         display: block;
-        height: 1em;
-        width: 1em;
+        height: auto;
+        width: auto;
     }
     .texticon-inner-icon {
         display: flex;


### PR DESCRIPTION
If for example the constant plugin.bootstrap_package_contentelements.texticon.icon.medium.height  and plugin.bootstrap_package_contentelements.texticon.icon.medium.width is changed to 60 the icon doesnt appear bigger in the frontend even if the img size is 60x60. It stays small. Either remove height and width totally or set it to auto.

Fixes # .

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

If for example the constant plugin.bootstrap_package_contentelements.texticon.icon.medium.height  and plugin.bootstrap_package_contentelements.texticon.icon.medium.width is changed to 60 the icon doesnt appear bigger in the frontend even if the img size is 60x60. It stays small. Either remove height and width totally or set it to auto.

### Steps to Validate

1. Change plugin.bootstrap_package_contentelements.texticon.icon.medium.height  and plugin.bootstrap_package_contentelements.texticon.icon.medium.width to 60
2. Check the frontend
3. The image size is 60x60 but the box is still 48x48