### PR TITLE
Fix Header on PageLoad if scrolled

### DIFF
--- a/Resources/Public/JavaScript/Dist/bootstrap.stickyheader.min.js
+++ b/Resources/Public/JavaScript/Dist/bootstrap.stickyheader.min.js
@@ -1,1 +1,1 @@
-$(function(){$(window).on("resize, scroll",function(){150<$(window).scrollTop()?$(".navbar-fixed-top").addClass("navbar-transition"):$(".navbar-fixed-top").removeClass("navbar-transition")})});
+$(function animateHeader(){$(window).on('resize, scroll',function(){var stickyheaderScrolled=$(window).scrollTop();if(stickyheaderScrolled>150){$('.navbar-fixed-top').addClass('navbar-transition')}else{$('.navbar-fixed-top').removeClass('navbar-transition')}});document.addEventListener("DOMContentLoaded",function(n){animateHeader()})});

--- a/Resources/Public/JavaScript/Src/bootstrap.stickyheader.js
+++ b/Resources/Public/JavaScript/Src/bootstrap.stickyheader.js
@@ -1,6 +1,6 @@
-$(function () {
+$(function animateHeader() {
 
-    $(window).on('resize, scroll', function () {
+    $(window).on('resize, scroll', function() {
         var stickyheaderScrolled = $(window).scrollTop();
         if (stickyheaderScrolled > 150) {
             $('.navbar-fixed-top').addClass('navbar-transition');
@@ -8,5 +8,8 @@ $(function () {
             $('.navbar-fixed-top').removeClass('navbar-transition');
         }
     });
+  	document.addEventListener("DOMContentLoaded", function(n) {
+    	animateHeader()
+	})
 
 });


### PR DESCRIPTION
Fixes # .

Adds eventlistener to check if page is scrolled at start and minimize header if so.

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

Changed:

- bootstrap.stickyheader.js
- bootstrap.stickyheader.min.js


### Steps to Validate

1. Call https://www.bootstrap-package.com/
2. Scroll down untill Header changes
3. reload with F5 and see the header beeing transparent. This is a JS Bug

### Solution
Named the function who changes the Header "`animateHeader`"
and added:
```
document.addEventListener("DOMContentLoaded", function(n) {
    	animateHeader()
})
```