### PR TITLE
[BUGFIX] Format raw HTML by lib.parseFunc for link handling

### DIFF
--- a/Resources/Private/Templates/ContentElements/Html.html
+++ b/Resources/Private/Templates/ContentElements/Html.html
@@ -3,7 +3,7 @@
 <f:section name="Header" />
 <f:section name="Main">
 
-    <f:format.raw>{data.bodytext}</f:format.raw>
+    <f:format.html parseFuncTSPath="lib.parseFunc">{data.bodytext}</f:format.html>
 
 </f:section>
 </html>


### PR DESCRIPTION
Fixes #729

### Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

### Description

This patch forces the parsing of raw HTML content by `lib.parseFunc` to ensure a correct link resolution and handling

### Steps to Validate

1. Create a HTML content element
2. Place some links with <a> or <link> tags
3. Verify the frontend output
