### PR TITLE
[BUGFIX] Install build tools

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,6 +14,10 @@ nfs_mount_enabled: false
 provider: default
 use_dns_when_possible: true
 timezone: ""
+webimage_extra_packages: [build-essential]
+hooks:
+  post-start:
+    - exec: sudo npm install -g grunt
 
 
 # This config.yaml was created with ddev version v1.12.0


### PR DESCRIPTION
This patch installs the build tools to the web container to enable the execution of yarn and grunt in the container.

Followup of #808