### PR TITLE
[TASK] Add typo3fluid/fluid to composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "typo3/cms-rte-ckeditor": "^9.5 || ^10.0 || 10.*@dev",
         "typo3/cms-seo": "^9.5 || ^10.0 || 10.*@dev",
         "scssphp/scssphp": "^1.0.6",
-        "typo3fluid/fluid": "^2.6"
+        "typo3fluid/fluid": "^2.5.2"
     },
     "require-dev": {
         "typo3/cms-felogin": "^9.5 || ^10.0 || 10.*@dev",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
         "typo3/cms-install": "^9.5 || ^10.0 || 10.*@dev",
         "typo3/cms-rte-ckeditor": "^9.5 || ^10.0 || 10.*@dev",
         "typo3/cms-seo": "^9.5 || ^10.0 || 10.*@dev",
-        "scssphp/scssphp": "^1.0.6"
+        "scssphp/scssphp": "^1.0.6",
+        "typo3fluid/fluid": "^2.6"
     },
     "require-dev": {
         "typo3/cms-felogin": "^9.5 || ^10.0 || 10.*@dev",


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

For me it looks like the dependency for `typo3fluid/fluid` is missing in composer e.g. the InlineSvgViewHlper is requiring the `TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper`.
https://github.com/benjaminkott/bootstrap_package/blob/master/Classes/ViewHelpers/InlineSvgViewHelper.php#L17

It can be that most people have the `typo3fluid/fluid` include in their projects, but as it's used here directly it should in my opinion be a hard dependency. 