### PR TITLE
[BUGFIX] Missing body class for current language

### DIFF
--- a/Configuration/TypoScript/Helper/PageClass.typoscript
+++ b/Configuration/TypoScript/Helper/PageClass.typoscript
@@ -18,7 +18,7 @@ lib.page.class {
     // Language
     30 = TEXT
     30 {
-        data = siteLanguage:twoLetterIsoCode
+        data = siteLanguage:languageId
         noTrimWrap = | language-||
     }
     // Backend layout

--- a/Configuration/TypoScript/Helper/PageClass.typoscript
+++ b/Configuration/TypoScript/Helper/PageClass.typoscript
@@ -18,7 +18,7 @@ lib.page.class {
     // Language
     30 = TEXT
     30 {
-        data = TSFE:sys_language_uid
+        data = siteLanguage:twoLetterIsoCode
         noTrimWrap = | language-||
     }
     // Backend layout


### PR DESCRIPTION
**TSFE:sys_language_uid** is marked deprecated since TYPO3 v9.4 and **siteLanguage:twoLetterIsoCode** or **siteLanguage:languageId** should be used.

## Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [ ] Changes have been tested on PHP 7.2.x
* [x] Changes have been tested on PHP 7.4.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

This patch fix the missing class for the current  language in body tag.

## Steps to Validate

1. Visit [www.bootstrap-package.com](https://www.bootstrap-package.com/)
2. Open the Inspector or check the page source code (body tag)
