### PR TITLE
[TASK] Migrate to afterExtensionInstall signal

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -81,8 +81,8 @@ if (TYPO3_MODE === 'BE') {
      * Provide example webserver configuration after extension is installed.
      */
     $signalSlotDispatcher->connect(
-        \TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService::class,
-        'hasInstalledExtensions',
+        \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,
+        'afterExtensionInstall',
         \BK2K\BootstrapPackage\Service\InstallService::class,
         'generateApacheHtaccess'
     );
@@ -91,8 +91,8 @@ if (TYPO3_MODE === 'BE') {
      * Add backend styling
      */
     $signalSlotDispatcher->connect(
-        \TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService::class,
-        'hasInstalledExtensions',
+        \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,
+        'afterExtensionInstall',
         \BK2K\BootstrapPackage\Service\BrandingService::class,
         'setBackendStyling'
     );


### PR DESCRIPTION
See deprecation #85462 (https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.4/Deprecation-85462-SignalHasInstalledExtensions.html)