### PR TITLE
[!!!][TASK] Remove TYPO3 9.5 and add 11 support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        typo3: ['^9', '^10', '^11']
+        typo3: ['^10', '^11']
         php: ['7.2', '7.3', '7.4']
         exclude:
           - typo3: '^11'

--- a/Classes/Backend/ToolbarItem/VersionToolbarItem.php
+++ b/Classes/Backend/ToolbarItem/VersionToolbarItem.php
@@ -9,6 +9,7 @@
 
 namespace BK2K\BootstrapPackage\Backend\ToolbarItem;
 
+use TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent;
 use TYPO3\CMS\Backend\Backend\ToolbarItems\SystemInformationToolbarItem;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -18,6 +19,11 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  */
 class VersionToolbarItem
 {
+    public function __invoke(SystemInformationToolbarCollectorEvent $event): void
+    {
+        $this->addVersionInformation($event->getToolbarItem());
+    }
+
     /**
      * Called by the system information toolbar signal/slot dispatch.
      *

--- a/Classes/Hooks/PageRenderer/FontLoaderHook.php
+++ b/Classes/Hooks/PageRenderer/FontLoaderHook.php
@@ -50,7 +50,7 @@ class FontLoaderHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (TYPO3_MODE !== 'FE' ||
+        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) ||
             (!is_array($params['cssFiles']) && !is_array($params['cssLibs']))
         ) {
             return;

--- a/Classes/Hooks/PageRenderer/FontLoaderHook.php
+++ b/Classes/Hooks/PageRenderer/FontLoaderHook.php
@@ -9,6 +9,8 @@
 
 namespace BK2K\BootstrapPackage\Hooks\PageRenderer;
 
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -50,7 +52,8 @@ class FontLoaderHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) ||
+        if (!($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface ||
+            !ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() ||
             (!is_array($params['cssFiles']) && !is_array($params['cssLibs']))
         ) {
             return;

--- a/Classes/Hooks/PageRenderer/GoogleFontHook.php
+++ b/Classes/Hooks/PageRenderer/GoogleFontHook.php
@@ -11,6 +11,8 @@ declare(strict_types = 1);
 namespace BK2K\BootstrapPackage\Hooks\PageRenderer;
 
 use BK2K\BootstrapPackage\Service\GoogleFontService;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\TypoScript\TemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -38,7 +40,8 @@ class GoogleFontHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) ||
+        if (!($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface ||
+            !ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() ||
             (!is_array($params['cssFiles']) && !is_array($params['cssLibs']))
         ) {
             return;

--- a/Classes/Hooks/PageRenderer/GoogleFontHook.php
+++ b/Classes/Hooks/PageRenderer/GoogleFontHook.php
@@ -38,7 +38,7 @@ class GoogleFontHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (TYPO3_MODE !== 'FE' ||
+        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE) ||
             (!is_array($params['cssFiles']) && !is_array($params['cssLibs']))
         ) {
             return;

--- a/Classes/Hooks/PageRenderer/PreProcessHook.php
+++ b/Classes/Hooks/PageRenderer/PreProcessHook.php
@@ -10,6 +10,8 @@
 namespace BK2K\BootstrapPackage\Hooks\PageRenderer;
 
 use BK2K\BootstrapPackage\Service\CompileService;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -28,7 +30,8 @@ class PreProcessHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE)) {
+        if (!($GLOBALS['TYPO3_REQUEST'] ?? null) instanceof ServerRequestInterface ||
+            !ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend()) {
             return;
         }
 

--- a/Classes/Hooks/PageRenderer/PreProcessHook.php
+++ b/Classes/Hooks/PageRenderer/PreProcessHook.php
@@ -28,9 +28,10 @@ class PreProcessHook
      */
     public function execute(&$params, &$pagerenderer)
     {
-        if (TYPO3_MODE !== 'FE') {
+        if (!(TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_FE)) {
             return;
         }
+
         foreach (['cssLibs', 'cssFiles'] as $key) {
             $files = [];
             if (is_array($params[$key])) {

--- a/Classes/Service/BrandingService.php
+++ b/Classes/Service/BrandingService.php
@@ -10,6 +10,7 @@
 namespace BK2K\BootstrapPackage\Service;
 
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -20,7 +21,12 @@ class BrandingService
     /**
      * @var string
      */
-    const EXT_KEY = 'bootstrap_package';
+    protected const EXT_KEY = 'bootstrap_package';
+
+    public function __invoke(AfterPackageActivationEvent $event): void
+    {
+        $this->setBackendStyling($event->getPackageKey());
+    }
 
     /**
      * @param string $extension

--- a/Configuration/Form/Setup.yaml
+++ b/Configuration/Form/Setup.yaml
@@ -10,7 +10,7 @@ TYPO3:
                         Form:
                             renderingOptions:
                                 translation:
-                                    translationFile:
+                                    translationFiles:
                                         110: 'EXT:bootstrap_package/Resources/Private/Language/locallang.xlf'
                                 layoutRootPaths:
                                     20: 'EXT:bootstrap_package/Resources/Private/Layouts/Form/'

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,11 @@
+services:
+  BK2K\BootstrapPackage\Service\BrandingService:
+    tags:
+      - name: event.listener
+        identifier: 'bk2k/bootstrap-package/set-backend-styling'
+        event: TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent
+  BK2K\BootstrapPackage\Backend\ToolbarItem\VersionToolbarItem:
+    tags:
+      - name: event.listener
+        identifier: 'bk2k/bootstrap-package/add-version-information'
+        event: TYPO3\CMS\Backend\Backend\Event\SystemInformationToolbarCollectorEvent

--- a/Configuration/TCA/Overrides/100_pages.php
+++ b/Configuration/TCA/Overrides/100_pages.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Temporary variables

--- a/Configuration/TCA/Overrides/101_sys_template.php
+++ b/Configuration/TCA/Overrides/101_sys_template.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * TypoScript: Full Package

--- a/Configuration/TCA/Overrides/102_tt_content.php
+++ b/Configuration/TCA/Overrides/102_tt_content.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element group to selector list

--- a/Configuration/TCA/Overrides/200_content_element_accordion.php
+++ b/Configuration/TCA/Overrides/200_content_element_accordion.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/201_content_element_audio.php
+++ b/Configuration/TCA/Overrides/201_content_element_audio.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/202_content_element_bullets.php
+++ b/Configuration/TCA/Overrides/202_content_element_bullets.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/203_content_element_card_group.php
+++ b/Configuration/TCA/Overrides/203_content_element_card_group.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/204_content_element_carousel.php
+++ b/Configuration/TCA/Overrides/204_content_element_carousel.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/205_content_element_carousel_small.php
+++ b/Configuration/TCA/Overrides/205_content_element_carousel_small.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/206_content_element_carousel_fullscreen.php
+++ b/Configuration/TCA/Overrides/206_content_element_carousel_fullscreen.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/207_content_element_csv.php
+++ b/Configuration/TCA/Overrides/207_content_element_csv.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/208_content_element_externalmedia.php
+++ b/Configuration/TCA/Overrides/208_content_element_externalmedia.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/209_content_element_header.php
+++ b/Configuration/TCA/Overrides/209_content_element_header.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/210_content_element_icon_group.php
+++ b/Configuration/TCA/Overrides/210_content_element_icon_group.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/211_content_element_image.php
+++ b/Configuration/TCA/Overrides/211_content_element_image.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/212_content_element_listgroup.php
+++ b/Configuration/TCA/Overrides/212_content_element_listgroup.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/213_content_element_media.php
+++ b/Configuration/TCA/Overrides/213_content_element_media.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/214_content_element_menu_card_list.php
+++ b/Configuration/TCA/Overrides/214_content_element_menu_card_list.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Enable Content Element

--- a/Configuration/TCA/Overrides/215_content_element_menu_card_dir.php
+++ b/Configuration/TCA/Overrides/215_content_element_menu_card_dir.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Enable Content Element

--- a/Configuration/TCA/Overrides/216_content_element_menu_thumbnail_list.php
+++ b/Configuration/TCA/Overrides/216_content_element_menu_thumbnail_list.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Enable Content Element

--- a/Configuration/TCA/Overrides/217_content_element_menu_thumbnail_dir.php
+++ b/Configuration/TCA/Overrides/217_content_element_menu_thumbnail_dir.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Enable Content Element

--- a/Configuration/TCA/Overrides/218_content_element_panel.php
+++ b/Configuration/TCA/Overrides/218_content_element_panel.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/219_content_element_quote.php
+++ b/Configuration/TCA/Overrides/219_content_element_quote.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/220_content_element_social_links.php
+++ b/Configuration/TCA/Overrides/220_content_element_social_links.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/221_content_element_tab.php
+++ b/Configuration/TCA/Overrides/221_content_element_tab.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/222_content_element_table.php
+++ b/Configuration/TCA/Overrides/222_content_element_table.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/223_content_element_text.php
+++ b/Configuration/TCA/Overrides/223_content_element_text.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/224_content_element_textcolumn.php
+++ b/Configuration/TCA/Overrides/224_content_element_textcolumn.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/225_content_element_texticon.php
+++ b/Configuration/TCA/Overrides/225_content_element_texticon.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/226_content_element_textmedia.php
+++ b/Configuration/TCA/Overrides/226_content_element_textmedia.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/227_content_element_textpic.php
+++ b/Configuration/TCA/Overrides/227_content_element_textpic.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/228_content_element_textteaser.php
+++ b/Configuration/TCA/Overrides/228_content_element_textteaser.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/229_content_element_timeline.php
+++ b/Configuration/TCA/Overrides/229_content_element_timeline.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/230_content_element_uploads.php
+++ b/Configuration/TCA/Overrides/230_content_element_uploads.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add content element PageTSConfig

--- a/Configuration/TCA/Overrides/231_content_element_gallery.php
+++ b/Configuration/TCA/Overrides/231_content_element_gallery.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Content Element

--- a/Configuration/TCA/Overrides/300_content_general_columns.php
+++ b/Configuration/TCA/Overrides/300_content_general_columns.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Adjust columns for generic usage

--- a/Configuration/TCA/Overrides/301_content_general_palettes.php
+++ b/Configuration/TCA/Overrides/301_content_general_palettes.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add Palettes for Generic usage

--- a/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
@@ -10,7 +10,7 @@
 defined('TYPO3') || die();
 
 // Activate T3EDITOR if extension is activated
-if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_BE) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')) {
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')) {
     $GLOBALS['TCA']['tx_bootstrappackage_carousel_item']['types']['html']['columnsOverrides'] = [
         'bodytext' => [
             'config' => [

--- a/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
@@ -7,10 +7,10 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 // Activate T3EDITOR if extension is activated
-if (TYPO3_MODE === 'BE' && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')) {
+if ((TYPO3_REQUESTTYPE & TYPO3_REQUESTTYPE_BE) && \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')) {
     $GLOBALS['TCA']['tx_bootstrappackage_carousel_item']['types']['html']['columnsOverrides'] = [
         'bodytext' => [
             'config' => [

--- a/Configuration/TCA/Overrides/500_cropping.php
+++ b/Configuration/TCA/Overrides/500_cropping.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Add crop variants

--- a/Tests/Packages/demo_package/Configuration/TCA/Overrides/sys_template.php
+++ b/Tests/Packages/demo_package/Configuration/TCA/Overrides/sys_template.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /**
  * Default TypoScript for DemoPackage

--- a/Tests/Packages/demo_package/ext_localconf.php
+++ b/Tests/Packages/demo_package/ext_localconf.php
@@ -7,4 +7,4 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();

--- a/Tests/Packages/demo_package/ext_tables.php
+++ b/Tests/Packages/demo_package/ext_tables.php
@@ -7,4 +7,4 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();

--- a/composer.json
+++ b/composer.json
@@ -83,8 +83,6 @@
         "vendor-dir": ".build/vendor",
         "bin-dir": ".build/bin"
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts": {
         "test:php:lint": [
             "phplint"

--- a/composer.json
+++ b/composer.json
@@ -33,38 +33,38 @@
     },
     "require": {
         "php": ">=7.2.0",
+        "ext-PDO": "*",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
         "ext-json": "*",
         "ext-libxml": "*",
-        "ext-PDO": "*",
         "ext-simplexml": "*",
-        "typo3/cms-backend": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-core": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-extbase": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-extensionmanager": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-fluid": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-frontend": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-install": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-rte-ckeditor": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-seo": "^9.5 || ^10.4 || 11.*.*@dev",
         "scssphp/scssphp": "^1.4.1",
+        "typo3/cms-backend": "^10.4 || ^11.0",
+        "typo3/cms-core": "^10.4 || ^11.0",
+        "typo3/cms-extbase": "^10.4 || ^11.0",
+        "typo3/cms-extensionmanager": "^10.4 || ^11.0",
+        "typo3/cms-fluid": "^10.4 || ^11.0",
+        "typo3/cms-frontend": "^10.4 || ^11.0",
+        "typo3/cms-install": "^10.4 || ^11.0",
+        "typo3/cms-rte-ckeditor": "^10.4 || ^11.0",
+        "typo3/cms-seo": "^10.4 || ^11.0",
         "typo3fluid/fluid": "^2.5.2"
     },
     "require-dev": {
-        "typo3/cms-felogin": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-form": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-indexed-search": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-info": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-lowlevel": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-tstemplate": "^9.5 || ^10.4 || 11.*.*@dev",
-        "typo3/cms-workspaces": "^9.5 || ^10.4 || 11.*.*@dev",
-        "friendsofphp/php-cs-fixer": "^2.3.1",
-        "typo3/testing-framework": "^4.15 || ^5.0 || ^6.4",
         "bk2k/demo-package": "@dev",
         "bk2k/extension-helper": "^1.0",
-        "overtrue/phplint": "^1.1"
+        "friendsofphp/php-cs-fixer": "^2.3.1",
+        "overtrue/phplint": "^1.1",
+        "typo3/cms-felogin": "^10.4 || ^11.0",
+        "typo3/cms-form": "^10.4 || ^11.0",
+        "typo3/cms-indexed-search": "^10.4 || ^11.0",
+        "typo3/cms-info": "^10.4 || ^11.0",
+        "typo3/cms-lowlevel": "^10.4 || ^11.0",
+        "typo3/cms-tstemplate": "^10.4 || ^11.0",
+        "typo3/cms-workspaces": "^10.4 || ^11.0",
+        "typo3/testing-framework": "^5.0 || ^6.4"
     },
     "autoload": {
         "psr-4": {
@@ -79,6 +79,7 @@
     "prefer-stable": true,
     "config": {
         "optimize-autoloader": true,
+        "sort-packages": true,
         "vendor-dir": ".build/vendor",
         "bin-dir": ".build/bin"
     },
@@ -118,7 +119,7 @@
             "app-dir": ".build"
         },
         "branch-alias": {
-            "dev-master": "11.1.x-dev"
+            "dev-master": "12.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,8 @@
         "vendor-dir": ".build/vendor",
         "bin-dir": ".build/bin"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "test:php:lint": [
             "phplint"

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Define TypoScript as content rendering template

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -74,30 +74,6 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
     '));
 }
 
-if (TYPO3_MODE === 'BE') {
-    $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-
-    /**
-     * Add backend styling
-     */
-    $signalSlotDispatcher->connect(
-        \TYPO3\CMS\Extensionmanager\Utility\InstallUtility::class,
-        'afterExtensionInstall',
-        \BK2K\BootstrapPackage\Service\BrandingService::class,
-        'setBackendStyling'
-    );
-
-    /**
-     * Add current Bootstrap Package version to system information toolbar
-     */
-    $signalSlotDispatcher->connect(
-        \TYPO3\CMS\Backend\Backend\ToolbarItems\SystemInformationToolbarItem::class,
-        'getSystemInformation',
-        \BK2K\BootstrapPackage\Backend\ToolbarItem\VersionToolbarItem::class,
-        'addVersionInformation'
-    );
-}
-
 /***************
  * Register google font hook
  */

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') || die();
+defined('TYPO3') || die();
 
 /***************
  * Allow Custom Records on Standard Pages


### PR DESCRIPTION
Preparation for TYPO3 v11 support.

Pending task (@benjaminkott):

- [x] Deployment in Travis is still missing in GH Actions
- [x] Travis has to be removed or adapted properly
- [x] Scrutinizer has to be removed or adapted properly
- [x] Expected checks for 9 have to be removed and added for 11 in GH settings