### PR TITLE
Revert "[BUGFIX] Use image vh for image types to enable thumbnails for non images like PDF files (#913)"

### DIFF
--- a/Resources/Private/Templates/ContentElements/Uploads.html
+++ b/Resources/Private/Templates/ContentElements/Uploads.html
@@ -11,14 +11,7 @@
                             <f:if condition="{f:uri.image(src: 'file:{f:if(condition: file.originalFile, then: \'file:{file.originalFile.uid}\', else: \'file:{file.uid}\')}')} != '/'">
                                 <div class="media-left">
                                     <a href="{file.publicUrl}"{f:if(condition: file.properties.title, then: ' title="{file.properties.title}"')}{f:if(condition: data.target, then: ' target="{data.target}"')}>
-                                        <f:if condition="{file -> bk2k:file.isImage()}">
-                                            <f:then>
-                                                <f:image image="{file}" width="{settings.uploads.preview.width}" height="{settings.uploads.preview.height}" alt="{file.properties.alternative}" />
-                                            </f:then>
-                                            <f:else>
-                                                <f:media file="{file}" width="{settings.uploads.preview.width}" height="{settings.uploads.preview.height}" alt="{file.properties.alternative}" />
-                                            </f:else>
-                                        </f:if>
+                                        <f:media file="{file}" width="{settings.uploads.preview.width}" height="{settings.uploads.preview.height}" alt="{file.properties.alternative}" />
                                     </a>
                                 </div>
                             </f:if>


### PR DESCRIPTION
This reverts commit 826f6beb431853a5f396917cb2d20f3a29ac6c70.

This issue was caused by wrong database entries which can be solved by removing the assets in the admin tool. Clearing the caches only does not help here.