### PR TITLE
[BUGFIX] Wrong table classes and add missing ones

### DIFF
--- a/Configuration/RTE/Default.yaml
+++ b/Configuration/RTE/Default.yaml
@@ -22,15 +22,23 @@ editor:
         stylesSet:
             - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
             - { name: "Small", element: "small" }
+
             - { name: "Table", element: "table", attributes: { 'class': 'table' } }
             - { name: "Table Striped", element: "table", attributes: { 'class': 'table table-striped' } }
             - { name: "Table Bordered", element: "table", attributes: { 'class': 'table table-bordered' } }
             - { name: "Table Condensed", element: "table", attributes: { 'class': 'table table-condensed' } }
-            - { name: "Row Active", element: "tr", attributes: { 'class': 'active' } }
-            - { name: "Row Success", element: "tr", attributes: { 'class': 'success' } }
-            - { name: "Row Info", element: "tr", attributes: { 'class': 'info' } }
-            - { name: "Row Warning", element: "tr", attributes: { 'class': 'warning' } }
-            - { name: "Row Danger", element: "tr", attributes: { 'class': 'danger' } }
+
+            - { name: "Row Active", element: "tr", attributes: { 'class': 'table-active' } }
+            - { name: "Row Success", element: "tr", attributes: { 'class': 'table-success' } }
+            - { name: "Row Info", element: "tr", attributes: { 'class': 'table-info' } }
+            - { name: "Row Warning", element: "tr", attributes: { 'class': 'table-warning' } }
+            - { name: "Row Danger", element: "tr", attributes: { 'class': 'table-danger' } }
+
+            - { name: "Cell Active", element: "td", attributes: { 'class': 'table-active' } }
+            - { name: "Cell Success", element: "td", attributes: { 'class': 'table-success' } }
+            - { name: "Cell Info", element: "td", attributes: { 'class': 'table-info' } }
+            - { name: "Cell Warning", element: "td", attributes: { 'class': 'table-warning' } }
+            - { name: "Cell Danger", element: "td", attributes: { 'class': 'table-danger' } }
 
             - { name: "Button Default", element: "a", attributes: { 'class': 'btn btn-default' } }
             - { name: "Button Primary", element: "a", attributes: { 'class': 'btn btn-primary' } }


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #728 

## Prerequisites

* [ ] Changes have been tested on TYPO3 v8.7 LTS
* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.0.x
* [ ] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Fixes wrong classes for table rows (tr) and adds classes for table data cells (td)

## Steps to Validate

1. Go to page Congratulations->Content Examples->Text->Rich Text
2. Edit content element "Tables"
3. Select styles for table rows and cells
