### PR TITLE
[BUGFIX] Make styles readable: set size of selectbox to 300px

### DIFF
--- a/Resources/Public/Css/Backend/ckeditor.css
+++ b/Resources/Public/Css/Backend/ckeditor.css
@@ -1,0 +1,7 @@
+.cke .cke_combo_text {
+    width: auto;
+}
+
+.cke.cke_combopanel {
+    width: 300px;
+}

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -18,3 +18,8 @@ defined('TYPO3_MODE') || die();
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_bootstrappackage_icon_group_item');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_bootstrappackage_tab_item');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_bootstrappackage_timeline_item');
+
+/***************
+ * Modify CSS for backend
+ */
+$GLOBALS['TBE_STYLES']['skins']['backend']['stylesheetDirectories']['bk2k'] = 'EXT:bootstrap_package/Resources/Public/Css/Backend/';


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #928

## Prerequisites

* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on PHP 7.2.x

## Description

Sets size of style selection to 300 px width (150 px is too small to display some styles like "Button Outline Default"
Also, the new configuration (stylesheetDirectories) can be used to fix some other quirks of TYPO3 BE. Just place a new CSS file in EXT:bootstrap_package/Resources/Public/Css/Backend/.
