### PR TITLE
[BUGFIX] Apply latest scssphp changes to import behavior

### DIFF
--- a/Classes/Parser/ScssParser.php
+++ b/Classes/Parser/ScssParser.php
@@ -96,7 +96,7 @@ class ScssParser extends AbstractParser
             // Resolve potential back paths manually using PathUtility::getCanonicalPath,
             // but make sure we do not break out of TYPO3 application path using GeneralUtility::getFileAbsFileName
             // Also resolve EXT: paths if given
-            $isTypo3Absolute = (strpos($url, 'EXT:') === 0) || (strpos($url, '/') === 0);
+            $isTypo3Absolute = (strpos($url, 'EXT:') === 0) || PathUtility::isAbsolutePath($url);
             $fileName = $isTypo3Absolute ? $url : $visualImportPath . '/' . $url;
             $full = GeneralUtility::getFileAbsFileName(PathUtility::getCanonicalPath($fileName));
             // The API forces us to check the existence of files paths, with or without url.

--- a/Classes/Parser/ScssParser.php
+++ b/Classes/Parser/ScssParser.php
@@ -96,7 +96,7 @@ class ScssParser extends AbstractParser
             // Resolve potential back paths manually using PathUtility::getCanonicalPath,
             // but make sure we do not break out of TYPO3 application path using GeneralUtility::getFileAbsFileName
             // Also resolve EXT: paths if given
-            $isTypo3Absolute = strpos($url, 'EXT:') === 0;
+            $isTypo3Absolute = (strpos($url, 'EXT:') === 0) || (strpos($url, '/') === 0);
             $fileName = $isTypo3Absolute ? $url : $visualImportPath . '/' . $url;
             $full = GeneralUtility::getFileAbsFileName(PathUtility::getCanonicalPath($fileName));
             // The API forces us to check the existence of files paths, with or without url.

--- a/Tests/Unit/Compiler/Fixtures/Calculation/Output.css
+++ b/Tests/Unit/Compiler/Fixtures/Calculation/Output.css
@@ -1,12 +1,13 @@
 .case-without-variable {
-  border-radius: 0.5rem; }
-
+  border-radius: 0.5rem;
+}
 .case-with-variable {
-  border-radius: 0.5rem; }
-
+  border-radius: 0.5rem;
+}
 .case-precalculated-variable {
-  border-radius: 0.25rem; }
-
+  border-radius: 0.25rem;
+}
 button {
   width: 0.5rem;
-  border-radius: 0.5rem; }
+  border-radius: 0.5rem;
+}


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #947

## Prerequisites

* [x] Changes have been tested on TYPO3 v8.7 LTS
* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 dev-master
* [x] Changes have been tested on PHP 7.0.x
* [x] Changes have been tested on PHP 7.1.x
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

This patch fixes our own scss import behavior with the latest changes at scssphp/scssphp version 1.4. Also the expectation of the CSS output is fixed.

## Steps to Validate

Run the functional tests with scssphp 1.4 and a lower release e.g. 1.3

The unit tests will fail with versions lower than 1.4 because of an other fix in scssphp 1.4.