### PR TITLE
[BUGFIX] Revert unintended revert of TYPO3 constant

### DIFF
--- a/Configuration/TCA/Overrides/100_pages.php
+++ b/Configuration/TCA/Overrides/100_pages.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Register PageTS
 

--- a/Configuration/TCA/Overrides/101_sys_template.php
+++ b/Configuration/TCA/Overrides/101_sys_template.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 /***************
  * TypoScript: Full Package

--- a/Configuration/TCA/Overrides/102_tt_content.php
+++ b/Configuration/TCA/Overrides/102_tt_content.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element group to selector list
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(

--- a/Configuration/TCA/Overrides/200_content_element_accordion.php
+++ b/Configuration/TCA/Overrides/200_content_element_accordion.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['accordion'])) {

--- a/Configuration/TCA/Overrides/201_content_element_audio.php
+++ b/Configuration/TCA/Overrides/201_content_element_audio.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['audio'])) {

--- a/Configuration/TCA/Overrides/202_content_element_bullets.php
+++ b/Configuration/TCA/Overrides/202_content_element_bullets.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/203_content_element_card_group.php
+++ b/Configuration/TCA/Overrides/203_content_element_card_group.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['card_group'])) {

--- a/Configuration/TCA/Overrides/204_content_element_carousel.php
+++ b/Configuration/TCA/Overrides/204_content_element_carousel.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['carousel'])) {

--- a/Configuration/TCA/Overrides/205_content_element_carousel_small.php
+++ b/Configuration/TCA/Overrides/205_content_element_carousel_small.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['carousel_small'])) {

--- a/Configuration/TCA/Overrides/206_content_element_carousel_fullscreen.php
+++ b/Configuration/TCA/Overrides/206_content_element_carousel_fullscreen.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['carousel_fullscreen'])) {

--- a/Configuration/TCA/Overrides/207_content_element_csv.php
+++ b/Configuration/TCA/Overrides/207_content_element_csv.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['csv'])) {

--- a/Configuration/TCA/Overrides/208_content_element_externalmedia.php
+++ b/Configuration/TCA/Overrides/208_content_element_externalmedia.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['external_media'])) {

--- a/Configuration/TCA/Overrides/209_content_element_header.php
+++ b/Configuration/TCA/Overrides/209_content_element_header.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/210_content_element_icon_group.php
+++ b/Configuration/TCA/Overrides/210_content_element_icon_group.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['icon_group'])) {

--- a/Configuration/TCA/Overrides/211_content_element_image.php
+++ b/Configuration/TCA/Overrides/211_content_element_image.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/212_content_element_listgroup.php
+++ b/Configuration/TCA/Overrides/212_content_element_listgroup.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['listgroup'])) {

--- a/Configuration/TCA/Overrides/213_content_element_media.php
+++ b/Configuration/TCA/Overrides/213_content_element_media.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['media'])) {

--- a/Configuration/TCA/Overrides/214_content_element_menu_card_list.php
+++ b/Configuration/TCA/Overrides/214_content_element_menu_card_list.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Enable Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['menu_card_list'])) {

--- a/Configuration/TCA/Overrides/215_content_element_menu_card_dir.php
+++ b/Configuration/TCA/Overrides/215_content_element_menu_card_dir.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Enable Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['menu_card_dir'])) {

--- a/Configuration/TCA/Overrides/216_content_element_menu_thumbnail_list.php
+++ b/Configuration/TCA/Overrides/216_content_element_menu_thumbnail_list.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Enable Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['menu_thumbnail_list'])) {

--- a/Configuration/TCA/Overrides/217_content_element_menu_thumbnail_dir.php
+++ b/Configuration/TCA/Overrides/217_content_element_menu_thumbnail_dir.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Enable Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['menu_thumbnail_dir'])) {

--- a/Configuration/TCA/Overrides/218_content_element_panel.php
+++ b/Configuration/TCA/Overrides/218_content_element_panel.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['panel'])) {

--- a/Configuration/TCA/Overrides/219_content_element_quote.php
+++ b/Configuration/TCA/Overrides/219_content_element_quote.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['quote'])) {

--- a/Configuration/TCA/Overrides/220_content_element_social_links.php
+++ b/Configuration/TCA/Overrides/220_content_element_social_links.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['social_links'])) {

--- a/Configuration/TCA/Overrides/221_content_element_tab.php
+++ b/Configuration/TCA/Overrides/221_content_element_tab.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['tab'])) {

--- a/Configuration/TCA/Overrides/222_content_element_table.php
+++ b/Configuration/TCA/Overrides/222_content_element_table.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/223_content_element_text.php
+++ b/Configuration/TCA/Overrides/223_content_element_text.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/224_content_element_textcolumn.php
+++ b/Configuration/TCA/Overrides/224_content_element_textcolumn.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['textcolumn'])) {

--- a/Configuration/TCA/Overrides/225_content_element_texticon.php
+++ b/Configuration/TCA/Overrides/225_content_element_texticon.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['texticon'])) {

--- a/Configuration/TCA/Overrides/226_content_element_textmedia.php
+++ b/Configuration/TCA/Overrides/226_content_element_textmedia.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/227_content_element_textpic.php
+++ b/Configuration/TCA/Overrides/227_content_element_textpic.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/228_content_element_textteaser.php
+++ b/Configuration/TCA/Overrides/228_content_element_textteaser.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['textteaser'])) {

--- a/Configuration/TCA/Overrides/229_content_element_timeline.php
+++ b/Configuration/TCA/Overrides/229_content_element_timeline.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['timeline'])) {

--- a/Configuration/TCA/Overrides/230_content_element_uploads.php
+++ b/Configuration/TCA/Overrides/230_content_element_uploads.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add content element PageTSConfig
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(

--- a/Configuration/TCA/Overrides/231_content_element_gallery.php
+++ b/Configuration/TCA/Overrides/231_content_element_gallery.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Content Element
 if (!is_array($GLOBALS['TCA']['tt_content']['types']['gallery'])) {

--- a/Configuration/TCA/Overrides/300_content_general_columns.php
+++ b/Configuration/TCA/Overrides/300_content_general_columns.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Adjust columns for generic usage
 $GLOBALS['TCA']['tt_content']['columns']['background_color_class'] = [

--- a/Configuration/TCA/Overrides/301_content_general_palettes.php
+++ b/Configuration/TCA/Overrides/301_content_general_palettes.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add Palettes for Generic usage
 $GLOBALS['TCA']['tt_content']['palettes']['header_minimal'] = [

--- a/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/Overrides/400_bootstrappackage_carousel_item.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Activate T3EDITOR if extension is activated
 if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('t3editor')) {

--- a/Configuration/TCA/Overrides/500_cropping.php
+++ b/Configuration/TCA/Overrides/500_cropping.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Add crop variants
 $defaultCropSettings = [

--- a/Tests/Packages/demo_package/Configuration/TCA/Overrides/sys_template.php
+++ b/Tests/Packages/demo_package/Configuration/TCA/Overrides/sys_template.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 /**
  * Default TypoScript for DemoPackage

--- a/Tests/Packages/demo_package/ext_localconf.php
+++ b/Tests/Packages/demo_package/ext_localconf.php
@@ -7,4 +7,4 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');

--- a/Tests/Packages/demo_package/ext_tables.php
+++ b/Tests/Packages/demo_package/ext_tables.php
@@ -7,4 +7,4 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Define TypoScript as content rendering template
 $GLOBALS['TYPO3_CONF_VARS']['FE']['contentRenderingTemplates'][] = 'bootstrappackage/Configuration/TypoScript/';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -7,7 +7,7 @@
  * LICENSE file that was distributed with this source code.
  */
 
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3') or die('Access denied.');
 
 // Allow Custom Records on Standard Pages
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_bootstrappackage_accordion_item');


### PR DESCRIPTION
The patch #1004 reverted changes of #984 for the TYPO3 11 compatibility.