### PR TITLE
[TASK] Disable deployment and publish workflows for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
       name: production
       url: https://bootstrap-package.com
     needs: [build-php, build-frontend]
-    if: (github.ref == 'refs/heads/master') && github.event_name != 'pull_request'
+    if: (github.ref == 'refs/heads/master') && github.event_name != 'pull_request' && (github.repository == 'benjaminkott/bootstrap_package')
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Publish new version to TER
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && (github.repository == 'benjaminkott/bootstrap_package')
     runs-on: ubuntu-20.04
     env:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}


### PR DESCRIPTION
Merging changes to forks leads to workflow errors and these new conditions avoid it.

![grafik](https://user-images.githubusercontent.com/25326036/121355738-798f9c00-c930-11eb-9769-6b6d990d34dd.png)
