### PR TITLE
[BUGFIX] SassError: compound selectors may no longer be extended.

### DIFF
--- a/Resources/Public/Scss/bootstrap5/compat/_form.scss
+++ b/Resources/Public/Scss/bootstrap5/compat/_form.scss
@@ -66,7 +66,7 @@ fieldset.form-group {
     }
 }
 .form-control.error {
-    @extend .form-control.is-invalid;
+    @extend .form-control, .is-invalid;
 }
 .has-error {
     .help-block {


### PR DESCRIPTION
SassError: compound selectors may no longer be extended. Consider `@extend .form-control, .is-invalid` instead. See: https://sass-lang.com/documentation/breaking-changes/extend-compound for details.