### PR TITLE
[BUGFIX] Remove wrong !default from monospace

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -530,6 +530,11 @@ parameters:
 			path: ../Classes/ViewHelpers/File/IsMediaViewHelper.php
 
 		-
+			message: "#^Instanceof between DOMElement and DOMElement will always evaluate to true\\.$#"
+			count: 1
+			path: ../Classes/ViewHelpers/InlineSvgViewHelper.php
+
+		-
 			message: "#^Variable property access on SimpleXMLElement\\.$#"
 			count: 2
 			path: ../Classes/ViewHelpers/InlineSvgViewHelper.php

--- a/Configuration/TypoScript/Bootstrap5/constants.typoscript
+++ b/Configuration/TypoScript/Bootstrap5/constants.typoscript
@@ -86,7 +86,7 @@ plugin.bootstrap_package {
             # cat=bootstrap 5.x: styling/bp5_006/001; type=string; label=$font-family-sans-serif:
             font-family-sans-serif = "#{$google-webfont}", sans-serif
             # cat=bootstrap 5.x: styling/bp5_006/002; type=string; label=$font-family-monospace:
-            font-family-monospace = SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
+            font-family-monospace = SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
             # cat=bootstrap 5.x: styling/bp5_010/001; type=options[Enabled=true, Disabled=false]; label=$enable-rounded:
             enable-rounded = true


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [x] Changes have been tested on PHP 7.4.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

The constant `font-family-monospace` has a `!default` appended which breaks its usage in browsers.
This patch removes the declaration.

## Steps to Validate

1. Insert `<code>foo</code>` with RTE
2. Check the frontend rendering
3. The rendered `<code>` uses a sans-serif font
