### PR TITLE
[REVERT][BUGFIX] SassError: compound selectors may no longer be extended.

### DIFF
--- a/Resources/Public/Scss/bootstrap5/compat/_form.scss
+++ b/Resources/Public/Scss/bootstrap5/compat/_form.scss
@@ -66,7 +66,7 @@ fieldset.form-group {
     }
 }
 .form-control.error {
-    @extend .form-control, .is-invalid;
+    @extend .form-control.is-invalid;
 }
 .has-error {
     .help-block {


### PR DESCRIPTION
Reverts benjaminkott/bootstrap_package#1023