### PR TITLE
[BUGFIX] Ignore phpstan error for dom_import_simplexml

### DIFF
--- a/Classes/ViewHelpers/InlineSvgViewHelper.php
+++ b/Classes/ViewHelpers/InlineSvgViewHelper.php
@@ -96,6 +96,7 @@ class InlineSvgViewHelper extends AbstractViewHelper
 
             // remove xml version tag
             $domXml = dom_import_simplexml($svgElement);
+            /** @phpstan-ignore-next-line */
             if (!$domXml instanceof \DOMElement || !$domXml->ownerDocument instanceof \DOMDocument) {
                 return '';
             }


### PR DESCRIPTION
The function dom_import_simplexml no longer returns null on failure with php 8.0.