### PR TITLE
[BUGFIX] Remove external softref to ext:rtehtmlarea

### DIFF
--- a/Configuration/TCA/Overrides/300_content_general_columns.php
+++ b/Configuration/TCA/Overrides/300_content_general_columns.php
@@ -122,7 +122,7 @@ $GLOBALS['TCA']['tt_content']['columns']['teaser'] = [
     'exclude' => true,
     'config' => [
         'type' => 'text',
-        'softref' => 'rtehtmlarea_images,typolink_tag',
+        'softref' => 'typolink_tag',
         'cols' => '40',
         'rows' => '3'
     ]


### PR DESCRIPTION
With the change https://review.typo3.org/c/Packages/TYPO3.CMS/+/70177
using rtehtmlarea_images in the softref config is not longer possible.