### PR TITLE
[BUGFIX] Remove deprecated softref `images`

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_accordion_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_accordion_item.php
@@ -209,7 +209,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '15',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],

--- a/Configuration/TCA/tx_bootstrappackage_card_group_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_card_group_item.php
@@ -281,7 +281,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '15',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],

--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -576,7 +576,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '5',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],

--- a/Configuration/TCA/tx_bootstrappackage_icon_group_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_icon_group_item.php
@@ -213,7 +213,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '15',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],

--- a/Configuration/TCA/tx_bootstrappackage_tab_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_tab_item.php
@@ -209,7 +209,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '15',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],

--- a/Configuration/TCA/tx_bootstrappackage_timeline_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_timeline_item.php
@@ -215,7 +215,7 @@ return [
                 'type' => 'text',
                 'cols' => '80',
                 'rows' => '15',
-                'softref' => 'typolink_tag,images,email[subst],url',
+                'softref' => 'typolink_tag,email[subst],url',
                 'enableRichtext' => true
             ],
         ],


### PR DESCRIPTION
With the change https://review.typo3.org/c/Packages/TYPO3.CMS/+/70177
using images in the softref config is not longer possible.