### PR TITLE
[TASK] Provide frontend build custom commands

### DIFF
--- a/.ddev/commands/web/build
+++ b/.ddev/commands/web/build
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+## Description: Builds the frontend files
+## Usage: build [flags] [args]
+## Example: "ddev build" or "ddev build --no-install" or "ddev build css" or "ddev build icon" or "ddev build image" or "ddev build js" or "ddev build lint"
+
+cd Build || exit 1
+
+install=1
+
+if [ "${1:-}" == "--no-install" ]; then
+    install=0
+    shift
+fi
+
+if [ "$install" -gt "0" ]; then
+    npm install || exit 1
+fi
+
+if [ -z "${1:-}" ]; then
+    command="build"
+else
+    command="$1"
+    shift
+fi
+
+npm run "$command" "$@"

--- a/.ddev/commands/web/npm
+++ b/.ddev/commands/web/npm
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+## Description: Run npm inside the web container in the Build folder
+## Usage: npm [flags] [args]
+## Example: "ddev npm install" or "ddev npm run build"
+
+cd Build || exit 1
+npm "$@"


### PR DESCRIPTION
This patch introduces two custom commands for DDEV to simplify the frontend related processes.

## `ddev npm`

Runs npm in the `Build` folder in the web container. Parameters are passed to npm. See also `ddev npm -h`.

## `ddev build`

Runs a script in the `Build` folder in the web container. Before the script is executed a `npm install` is performed which can be skipped by adding the `--no-install` option. Default script is `build` or provide the script name as parameter. See also `ddev build -h`.