### PR TITLE
[FIX] default localized accordion items

### DIFF
--- a/Resources/Private/Templates/ContentElements/Accordion.html
+++ b/Resources/Private/Templates/ContentElements/Accordion.html
@@ -9,7 +9,7 @@
             <f:for each="{records}" as="record" iteration="iteration">
                 <div class="accordion-item">
                     <h4 class="accordion-header" id="accordion-heading-{data.uid}-{record.data.uid}">
-                        <button class="accordion-button{f:if(condition: '{activeElement} == {record.data.uid}', else:' collapsed')}" type="button"
+                        <button class="accordion-button{f:if(condition: '{activeElement} == {record.data.uid} || {activeElement} == {record.data._LOCALIZED_UID}', else:' collapsed')}" type="button"
                             data-toggle="collapse"
                             data-target="#accordion-{data.uid}-{record.data.uid}"
                             data-parent="#accordion-{data.uid}"


### PR DESCRIPTION
localized default accordion items not working. localized items getting the same {record.data.uid}.

# Pull Request

## Prerequisites
Tested with:
* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [x] Changes have been tested on PHP 7.4.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description
Tested with bk2k/bootstrap-package 11.0.3 & 12.0.1