### PR TITLE
[BUGFIX] Abuse of storage 0 for extension resources

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to function method_exists\\(\\) with 'TYPO3\\\\\\\\CMS\\\\\\\\Core\\\\\\\\Utility\\\\\\\\PathUtility' and 'getPublicResourceWe…' will always evaluate to true\\.$#"
+			count: 1
+			path: ../Classes/DataProcessing/StaticFilesProcessor.php
+
+		-
+			message: "#^Call to an undefined static method TYPO3\\\\CMS\\\\Core\\\\Utility\\\\PathUtility::getPublicResourceWebPath\\(\\).$#"
+			count: 1
+			path: ../Classes/DataProcessing/StaticFilesProcessor.php
+
+		-
 			message:
 				"""
 					#^Call to deprecated method fetch\\(\\) of class Doctrine\\\\DBAL\\\\Driver\\\\ResultStatement\\:

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -236,6 +236,7 @@ page {
                     normal = {$page.logo.file}
                     inverted = {$page.logo.fileInverted}
                 }
+                compatibilityMode = false
                 as = logo
             }
         }

--- a/Resources/Private/Partials/Page/Header/Logo.html
+++ b/Resources/Private/Partials/Page/Header/Logo.html
@@ -2,9 +2,9 @@
 <f:link.page pageUid="{rootPage}" class="navbar-brand navbar-brand-{f:if(condition: logo.normal, then: 'image', else: 'text')}" title="{settings.logo.linktitle}">
     <f:if condition="{logo.normal}">
         <f:then>
-            <img class="navbar-brand-logo-normal" src="{f:uri.image(image: logo.normal)}" alt="{logoAlt}" height="{settings.logo.height}" width="{settings.logo.width}">
+            <img class="navbar-brand-logo-normal" src="{logo.normal}" alt="{logoAlt}" height="{settings.logo.height}" width="{settings.logo.width}">
             <f:if condition="{logo.inverted}">
-                <img class="navbar-brand-logo-inverted" src="{f:uri.image(image: logo.inverted)}" alt="{logoAlt}" height="{settings.logo.height}" width="{settings.logo.width}">
+                <img class="navbar-brand-logo-inverted" src="{logo.inverted}" alt="{logoAlt}" height="{settings.logo.height}" width="{settings.logo.width}">
             </f:if>
         </f:then>
         <f:else>


### PR DESCRIPTION
This patch makes sure the virtual storage 0 is not longer abused by the
StaticFilesProcessor. Therefor the StaticFilesProcessor now returns URIs
of the provided files and not longer FILE objects.

All `EXT:` references are now properly resolved through
`PathUtility::getPublicResourceWebPath()` if available (TYPO3 11.4.0 and
higher) or by providing an absolute path to
`PathUtility::getAbsoluteWebPath`.

FAL resources are resolved using `PathUtility::getAbsoluteWebPath` also
by providing an absolute path.

The new behavior is disabled by default and can be enabled by setting
"compatibilityMode" to "false".