### PR TITLE
[BUGFIX] Do not call "libxml_disable_entity_loader" in PHP 8

### DIFF
--- a/Classes/Utility/SvgUtility.php
+++ b/Classes/Utility/SvgUtility.php
@@ -55,9 +55,14 @@ class SvgUtility
             }
 
             // Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
-            $previousValueOfEntityLoader = libxml_disable_entity_loader(true);
+            $previousValueOfEntityLoader = null;
+            if (PHP_MAJOR_VERSION < 8) {
+                $previousValueOfEntityLoader = libxml_disable_entity_loader(true);
+            }
             $svgElement = simplexml_load_string($svgContent);
-            libxml_disable_entity_loader($previousValueOfEntityLoader);
+            if (PHP_MAJOR_VERSION < 8) {
+                libxml_disable_entity_loader($previousValueOfEntityLoader);
+            }
             if (!$svgElement instanceof \SimpleXMLElement) {
                 return '';
             }

--- a/Classes/Utility/SvgUtility.php
+++ b/Classes/Utility/SvgUtility.php
@@ -55,7 +55,7 @@ class SvgUtility
             }
 
             // Disables the functionality to allow external entities to be loaded when parsing the XML, must be kept
-            $previousValueOfEntityLoader = null;
+            $previousValueOfEntityLoader = false;
             if (PHP_MAJOR_VERSION < 8) {
                 $previousValueOfEntityLoader = libxml_disable_entity_loader(true);
             }


### PR DESCRIPTION
See also https://github.com/TYPO3/typo3/commit/0a39476561e77e9bcb3786fcc973d4a49af41783.

Fixes #1104