### PR TITLE
[FEATURE] Use translatable labels for container names and columns

### DIFF
--- a/Configuration/TCA/Overrides/600_ext_container.php
+++ b/Configuration/TCA/Overrides/600_ext_container.php
@@ -76,7 +76,7 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_2_columns_left',
-                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_2_columns_left.name',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_2_columns_left.name',
                 '',
                 [
                     [
@@ -99,7 +99,7 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_3_columns',
-                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_3_columns.name',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_3_columns.name',
                 '',
                 [
                     [
@@ -124,7 +124,7 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_4_columns',
-                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_4_columns.name',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_4_columns.name',
                 '',
                 [
                     [

--- a/Configuration/TCA/Overrides/600_ext_container.php
+++ b/Configuration/TCA/Overrides/600_ext_container.php
@@ -15,12 +15,12 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_1_columns',
-                '1 Column',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_1_columns.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Middle',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.middle',
                             'colPos' => 201
                         ]
                     ]
@@ -32,16 +32,16 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_2_columns',
-                '2 Columns 50%/50%',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_2_columns.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.left',
                             'colPos' => 201
                         ],
                         [
-                            'name' => 'Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.right',
                             'colPos' => 202
                         ]
                     ]
@@ -53,17 +53,17 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_2_columns_right',
-                '2 Columns 25%/75%',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container_2_columns_right.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.left',
                             'colspan' => 1,
                             'colPos' => 201
                         ],
                         [
-                            'name' => 'Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.right',
                             'colspan' => 3,
                             'colPos' => 202
                         ]
@@ -76,17 +76,17 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_2_columns_left',
-                '2 Columns 75%/25%',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_2_columns_left.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.left',
                             'colspan' => 3,
                             'colPos' => 201
                         ],
                         [
-                            'name' => 'Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.right',
                             'colspan' => 2,
                             'colPos' => 202
                         ]
@@ -99,20 +99,20 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_3_columns',
-                '3 Columns',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_3_columns.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.left',
                             'colPos' => 201
                         ],
                         [
-                            'name' => 'Middle',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.middle',
                             'colPos' => 203
                         ],
                         [
-                            'name' => 'Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.right',
                             'colPos' => 202
                         ]
                     ]
@@ -124,24 +124,24 @@ if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('container')) {
         (
             new \B13\Container\Tca\ContainerConfiguration(
                 'container_4_columns',
-                '4 Columns',
+                'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.container.container_4_columns.name',
                 '',
                 [
                     [
                         [
-                            'name' => 'Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.left',
                             'colPos' => 201
                         ],
                         [
-                            'name' => 'Middle Left',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.middle_left',
                             'colPos' => 203
                         ],
                         [
-                            'name' => 'Middle Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.middle_right',
                             'colPos' => 204
                         ],
                         [
-                            'name' => 'Right',
+                            'name' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:container.column.right',
                             'colPos' => 202
                         ]
                     ]

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -839,7 +839,7 @@
 
             <trans-unit id="field.imageorient.125">
                 <source>Beside Text, Centered Right</source>
-           </trans-unit>
+            </trans-unit>
             <trans-unit id="field.imageorient.126">
                 <source>Beside Text, Centered Left</source>
             </trans-unit>
@@ -1031,7 +1031,39 @@
             <trans-unit id="field.readmore_label">
                 <source>Read More Label</source>
             </trans-unit>
-
+            <trans-unit id="container.container_1_columns.name">
+                <source>1 Column</source>
+            </trans-unit>
+            <trans-unit id="container.container_2_columns.name">
+                <source>2 Columns 50%/50%</source>
+            </trans-unit>
+            <trans-unit id="container.container_2_columns_right.name">
+                <source>2 Columns 25%/75%</source>
+            </trans-unit>
+            <trans-unit id="container.container_2_columns_left.name">
+                <source>2 Columns 75%/25%</source>
+            </trans-unit>
+            <trans-unit id="container.container_3_columns.name">
+                <source>3 Columns</source>
+            </trans-unit>
+            <trans-unit id="container.container_4_columns.name">
+                <source>4 Columns</source>
+            </trans-unit>
+            <trans-unit id="container.column.middle">
+                <source>Middle</source>
+            </trans-unit>
+            <trans-unit id="container.column.left">
+                <source>Left</source>
+            </trans-unit>
+            <trans-unit id="container.column.right">
+                <source>Right</source>
+            </trans-unit>
+            <trans-unit id="container.column.middle_left">
+                <source>Middle Left</source>
+            </trans-unit>
+            <trans-unit id="container.column.middle_right">
+                <source>Middle Right</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
# Pull Request

Labels in Ext:Container configuration are hardcoded
With this pull request, a translation option becomes easier

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [ x] Changes have been tested on PHP 7.4.x
* [ x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Changed TCA and Backend.xlf

