### PR TITLE
[BUGFIX] Add missing no-cookie to media additionalConfig

### DIFF
--- a/Configuration/TypoScript/ContentElement/Helper/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/Helper/ContentElement.typoscript
@@ -91,6 +91,7 @@ lib.contentElement {
                 showinfo = {$plugin.bootstrap_package_contentelements.media.additionalConfig.showinfo}
                 relatedVideos = {$plugin.bootstrap_package_contentelements.media.additionalConfig.relatedVideos}
                 modestbranding = {$plugin.bootstrap_package_contentelements.media.additionalConfig.modestbranding}
+                no-cookie = {$plugin.bootstrap_package_contentelements.media.additionalConfig.nocookie}
             }
         }
         gallery {

--- a/Configuration/TypoScript/ContentElement/constants.typoscript
+++ b/Configuration/TypoScript/ContentElement/constants.typoscript
@@ -64,6 +64,8 @@ plugin.bootstrap_package_contentelements {
             relatedVideos = 0
             # cat=bootstrap package: content elements/131_contentelement/007_modestbranding; type=boolean; label=Modest Branding
             modestbranding = 0
+            # cat=bootstrap package: content elements/131_contentelement/008_nocookie; type=boolean; label=No Cookie
+            nocookie = 1
         }
     }
     gallery {


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 dev-master
* [ ] Changes have been tested on PHP 7.2.x
* [ ] Changes have been tested on PHP 7.3.x
* [ ] Changes have been tested on PHP 7.4.x
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Add the missing no-cookie option for media (youtube and vimeo) and enabled it by default.
