### PR TITLE
[BUGFIX] Register classes in DI container for TYPO3 v12

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,9 +1,18 @@
 services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  BK2K\BootstrapPackage\:
+    resource: '../Classes/*'
+
   BK2K\BootstrapPackage\Service\BrandingService:
     tags:
       - name: event.listener
         identifier: 'bk2k/bootstrap-package/set-backend-styling'
         event: TYPO3\CMS\Core\Package\Event\AfterPackageActivationEvent
+
   BK2K\BootstrapPackage\Backend\ToolbarItem\VersionToolbarItem:
     tags:
       - name: event.listener


### PR DESCRIPTION
After installing bootstrap_package on TYPO3 v12, dependency injection is now able to find its classes.

It's related to this change https://review.typo3.org/c/Packages/TYPO3.CMS/+/72469