### PR TITLE
[BUGFIX]  Correct Bootstrap version in docu

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -10,7 +10,7 @@
 Introduction
 ==============================
 
-Bootstrap Package is a theme for TYPO3 CMS based on the `Bootstrap CSS Framework <http://getbootstrap.com/>`_ Version 3.3.7
+Bootstrap Package is a theme for TYPO3 CMS based on the `Bootstrap CSS Framework <http://getbootstrap.com/>`_ Version 5.1
 
 Features
 ==============================


### PR DESCRIPTION
Hi Benjamin, 
isn't the bootstrap_package based on bootstrap 5.1?
Best regards
Eckard.

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [x] Changes have been tested on TYPO3 v9.5 LTS
* [x] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 dev-master
* [x] Changes have been tested on PHP 7.2.x
* [x] Changes have been tested on PHP 7.3.x
* [x] Changes have been tested on PHP 7.4.x
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
