### PR TITLE
[BUGFIX] Avoid early fatal with TYPO3 v12

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -302,7 +302,7 @@ return [
                     ],
                 ],
                 'default' => 'header',
-                'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'],
+                'authMode' => $GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] ?? 'explicitAllow',
                 'authMode_enforce' => 'strict'
             ],
             'l10n_mode' => 'exclude',


### PR DESCRIPTION
$GLOBALS['TYPO3_CONF_VARS']['BE']['explicitADmode'] does
not exist anymore. Fall back to old default for <v12
compatibility. See [1] for details.

[1] https://forge.typo3.org/issues/97265