### PR TITLE
[BUGFIX] Avoid unitialized variable in VersionToolbarItem

### DIFF
--- a/Classes/Backend/ToolbarItem/VersionToolbarItem.php
+++ b/Classes/Backend/ToolbarItem/VersionToolbarItem.php
@@ -36,6 +36,7 @@ class VersionToolbarItem
 
         // Try to get current version from git
         if (file_exists($extensionDirectory . '.git')) {
+            $returnCode = 0;
             CommandUtility::exec('git --version', $_, $returnCode);
             if ((int)$returnCode === 0) {
                 $currentDir = (string) getcwd();


### PR DESCRIPTION
Third argument $returnValue of CommandUtility::exec() has been
type hinted to int in [1]. bootstrap_package fails now since
it uses a not initialized variable. Init properly.

[1] https://forge.typo3.org/issues/97206

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
