### PR TITLE
[BUGFIX] Change null coalesce operator to long ternary operator

### DIFF
--- a/Classes/DataProcessing/ContainerContextProcessor.php
+++ b/Classes/DataProcessing/ContainerContextProcessor.php
@@ -60,7 +60,7 @@ class ContainerContextProcessor implements DataProcessorInterface
     public function getPageRecords(ContentObjectRenderer $cObj, int $pid): array
     {
         $runtimeCache = GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime');
-        $cache = $runtimeCache->get('containerContext') ?: [];
+        $cache = \is_array($runtimeCache->get('containerContext')) ? $runtimeCache->get('containerContext') : [];
         $cacheIdentifier = 'containerContext:' . $pid;
 
         if (!isset($cache[$cacheIdentifier])) {

--- a/Classes/DataProcessing/ContainerContextProcessor.php
+++ b/Classes/DataProcessing/ContainerContextProcessor.php
@@ -60,7 +60,7 @@ class ContainerContextProcessor implements DataProcessorInterface
     public function getPageRecords(ContentObjectRenderer $cObj, int $pid): array
     {
         $runtimeCache = GeneralUtility::makeInstance(CacheManager::class)->getCache('runtime');
-        $cache = $runtimeCache->get('containerContext') ?? [];
+        $cache = $runtimeCache->get('containerContext') ?: [];
         $cacheIdentifier = 'containerContext:' . $pid;
 
         if (!isset($cache[$cacheIdentifier])) {


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [x] Changes have been tested on PHP 8.1
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

I get this error in TYPO3 v11, bootstrap_package v12.0.5 when using PHP 8.1:


```
(1/1) #1476107295 TYPO3\CMS\Core\Error\Exception
PHP Runtime Deprecation Notice: Automatic conversion of false to array is deprecated in /var/www/html/public/typo3conf/ext/bootstrap_package/Classes/DataProcessing/ContainerContextProcessor.php line 73
```

A quick debug revealed that the getter in line 63 in ContainerContextProcessor.php returns false:
`$cache = $runtimeCache->get('containerContext') ?? [];`

The shorthand ternary operator can solve this.

`$cache = $runtimeCache->get('containerContext') ?: [];`

## Steps to Validate

1. Setup TYPO3 v11 with PHP 8.1
2. Install bootstrap_package and containers via composer
3. Use container content element on any page
