### PR TITLE
Fixes carousel indicator navigation

### DIFF
--- a/Resources/Public/Scss/components/_carousel.scss
+++ b/Resources/Public/Scss/components/_carousel.scss
@@ -312,6 +312,9 @@ $carousel-item-layouts: map-merge(
             height: auto;
             background-color: transparent;
             cursor: pointer;
+            &.active {
+                position: relative;
+            }
             &.active:before {
                 content: '';
                 position: absolute;


### PR DESCRIPTION
Adds position: relative to .carousel .carousel-indicators-navigation>li.active so that the absolute positioned element .carousel .carousel-indicators-navigation>li.active::before is shown correct.

# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [x] Changes have been tested on PHP 8.1
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`