### PR TITLE
Removes default font-size

### DIFF
--- a/Resources/Public/Scss/components/card/_cardpanel.scss
+++ b/Resources/Public/Scss/components/card/_cardpanel.scss
@@ -93,7 +93,6 @@ $cardpanel-variants: map-merge(
     .card-header {
         background: var(--cardpanel-header-background);
         color: var(--cardpanel-header-color);
-        font-size: 1rem !important;
         padding: $card-spacer-y $card-spacer-x;
     }
 }


### PR DESCRIPTION
Removes default font-size, because the header tag is configurable (h1-h5) and so the font-size should reflect this.

# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [x] Changes have been tested on PHP 8.1
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`