### PR TITLE
[BUGFIX] Prevent PHP Runtime Deprecation Notice

### DIFF
--- a/Classes/DataProcessing/ContainerContextProcessor.php
+++ b/Classes/DataProcessing/ContainerContextProcessor.php
@@ -63,15 +63,18 @@ class ContainerContextProcessor implements DataProcessorInterface
         $cache = is_array($runtimeCache->get('containerContext')) ? $runtimeCache->get('containerContext') : [];
         $cacheIdentifier = 'containerContext:' . $pid;
 
-        if (!isset($cache[$cacheIdentifier])) {
+        if (!$cache || !isset($cache[$cacheIdentifier])) {
             $records = $cObj->getRecords('tt_content', ['pidInList' => $pid]);
             $dataset = [];
             foreach ($records as $record) {
                 $dataset[$record['uid']] = $record;
             }
 
-            $cache[$cacheIdentifier] = $dataset;
-            $runtimeCache->set('containerContext', $cache);
+            if ($cache) {
+                $cache[$cacheIdentifier] = $dataset;
+                $runtimeCache->set('containerContext', $cache);
+            }
+            return $dataset;
         }
 
         return $cache[$cacheIdentifier];


### PR DESCRIPTION
Check for existing cache before using it as an array to prevent
PHP Runtime Deprecation Notice: Automatic conversion of false to array is deprecated

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [x] Changes have been tested on PHP 8.1
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
