### PR TITLE
[BUGFIX] Prevent PHP Warning: Undefined array key

### DIFF
--- a/Classes/Userfuncs/Tca.php
+++ b/Classes/Userfuncs/Tca.php
@@ -16,6 +16,6 @@ class Tca
     public function timelineItemLabel(array &$parameters): void
     {
         $record = BackendUtility::getRecord($parameters['table'], $parameters['row']['uid']) ?? [];
-        $parameters['title'] = $record['date'] . ' - ' . $record['header'];
+        $parameters['title'] = ($record['date'] ?? '') . ' - ' . ($record['header'] ?? '');
     }
 }


### PR DESCRIPTION
PHP Warning: Undefined array key "header" and PHP Warning: Undefined array key "date"

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [x] Changes have been tested on PHP 8.1
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
