### PR TITLE
[BUGFIX] Fix undefined variables access (PHP 8+ compatibility)

### DIFF
--- a/Classes/ViewHelpers/Data/ImageVariantsViewHelper.php
+++ b/Classes/ViewHelpers/Data/ImageVariantsViewHelper.php
@@ -46,7 +46,7 @@ class ImageVariantsViewHelper extends AbstractViewHelper
         \Closure $renderChildrenClosure,
         RenderingContextInterface $renderingContext
     ) {
-        $variants = ImageVariantsUtility::getImageVariants($arguments['variants'], $arguments['multiplier'], $arguments['gutters'], $arguments['corrections'], $arguments['aspectRatio']);
+        $variants = ImageVariantsUtility::getImageVariants($arguments['variants'] ?? null, $arguments['multiplier'] ?? null, $arguments['gutters'] ?? null, $arguments['corrections'] ?? null, $arguments['aspectRatio'] ?? null);
         $renderingContext->getVariableProvider()->add($arguments['as'], $variants);
         return '';
     }

--- a/Classes/ViewHelpers/Format/TrimViewHelper.php
+++ b/Classes/ViewHelpers/Format/TrimViewHelper.php
@@ -29,6 +29,6 @@ class TrimViewHelper extends AbstractViewHelper
      */
     public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
     {
-        return trim($renderChildrenClosure());
+        return trim($renderChildrenClosure() ?? '');
     }
 }


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1217

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [x ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [x ] Changes have been tested on PHP 8.0
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Assign sane fallback values using the coalesce operator.

## Steps to Validate

1. See related issue
