### PR TITLE
Fix image width

### DIFF
--- a/Classes/Utility/ImageVariantsUtility.php
+++ b/Classes/Utility/ImageVariantsUtility.php
@@ -31,26 +31,26 @@ class ImageVariantsUtility
     protected static $defaultVariants = [
         'default' => [
             'breakpoint' => 1400,
-            'width' => 1280
+            'width' => 1320
         ],
         'xlarge' => [
             'breakpoint' => 1200,
-            'width' => 1100
+            'width' => 1140
         ],
         'large' => [
             'breakpoint' => 992,
-            'width' => 920
+            'width' => 960
         ],
         'medium' => [
             'breakpoint' => 768,
-            'width' => 680
+            'width' => 720
         ],
         'small' => [
             'breakpoint' => 576,
-            'width' => 500
+            'width' => 540
         ],
         'extrasmall' => [
-            'width' => 374
+            'width' => 400
         ]
     ];
 
@@ -67,11 +67,11 @@ class ImageVariantsUtility
         $variants = $variants !== null ? $variants : [];
         $variants = self::processVariants($variants);
         $variants = self::processResolutions($variants);
-        if ($gutters !== null) {
-            $variants = self::removeGutters($variants, $gutters);
-        }
         if ($multiplier !== null) {
             $variants = self::processMultiplier($variants, $multiplier);
+        }
+        if ($gutters !== null) {
+            $variants = self::removeGutters($variants, $gutters);
         }
         if ($corrections !== null) {
             $variants = self::processCorrections($variants, $corrections);

--- a/Configuration/TypoScript/ContentElement/Element/Accordion.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/Accordion.typoscript
@@ -51,27 +51,30 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 24
-                xlarge = 24
-                large = 24
-                medium = 24
+                // 50% of gap, which is 1rem=16px
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
             corrections {
-                default = 25
-                xlarge = 25
-                large = 25
-                medium = 25
-                small = 50
-                extrasmall = 50
+                // accordion padding, which is 1.25rem=20px
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
+                small = 40
+                extrasmall = 40
             }
         }
         top {
             corrections {
-                default = 50
-                large = 50
-                medium = 50
-                small = 50
-                extrasmall = 50
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
+                small = 20
+                extrasmall = 20
             }
         }
         right {
@@ -82,27 +85,27 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 24
-                xlarge = 24
-                large = 24
-                medium = 24
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
             corrections {
-                default = 25
-                xlarge = 25
-                large = 25
-                medium = 25
-                small = 50
-                extrasmall = 50
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
+                small = 40
+                extrasmall = 40
             }
         }
         bottom {
             corrections {
-                default = 50
-                large = 50
-                medium = 50
-                small = 50
-                extrasmall = 50
+                default = 20
+                large = 20
+                medium = 20
+                small = 20
+                extrasmall = 20
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Element/CardGroup.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/CardGroup.typoscript
@@ -70,11 +70,12 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                // 50% of --cardgroup-gap, which is 1rem=16px
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2
@@ -93,10 +94,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.3333
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
             corrections {
                 default = 2
@@ -116,11 +117,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2

--- a/Configuration/TypoScript/ContentElement/Element/MenuCardDir.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/MenuCardDir.typoscript
@@ -83,11 +83,12 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                // 50% of --cardmenu-gap, which is 1rem=16px
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2
@@ -106,10 +107,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.3333
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
             corrections {
                 default = 2
@@ -129,11 +130,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2

--- a/Configuration/TypoScript/ContentElement/Element/MenuCardList.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/MenuCardList.typoscript
@@ -84,11 +84,12 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                // 50% of --cardmenu-gap, which is 1rem=16px
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2
@@ -107,10 +108,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.3333
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
             corrections {
                 default = 2
@@ -130,11 +131,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 20
-                xlarge = 20
-                large = 20
-                medium = 20
-                small = 20
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
+                small = 8
             }
             corrections {
                 default = 2

--- a/Configuration/TypoScript/ContentElement/Element/MenuThumbnailDir.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/MenuThumbnailDir.typoscript
@@ -60,11 +60,12 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                // 50% of --thumbnailmenu-gap, which is 5px
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
         3 {
@@ -76,11 +77,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.3333
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
         4 {
@@ -92,11 +93,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Element/MenuThumbnailList.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/MenuThumbnailList.typoscript
@@ -61,11 +61,12 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                // 50% of --thumbnailmenu-gap, which is 5px
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
         3 {
@@ -77,11 +78,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.3333
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
         4 {
@@ -93,11 +94,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 small = 0.5
             }
             gutters {
-                default = 10
-                xlarge = 10
-                large = 10
-                medium = 10
-                small = 10
+                default = 2
+                xlarge = 2
+                large = 2
+                medium = 2
+                small = 2
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Element/Tab.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/Tab.typoscript
@@ -51,10 +51,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                // 50% of gap, which is 1rem=16px
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
         }
         right {
@@ -65,10 +66,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 8
+                xlarge = 8
+                large = 8
+                medium = 8
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Element/Textmedia.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/Textmedia.typoscript
@@ -53,10 +53,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                // 50% of gap, which is 40px
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         centered_right {
@@ -67,10 +68,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         left {
@@ -81,10 +82,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         right {
@@ -95,10 +96,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Element/Textpic.typoscript
+++ b/Configuration/TypoScript/ContentElement/Element/Textpic.typoscript
@@ -59,10 +59,11 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                // 50% of gap, which is 40px
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         centered_right {
@@ -73,10 +74,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         left {
@@ -87,10 +88,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
         right {
@@ -101,10 +102,10 @@ lib.contentElement.settings.responsiveimages.contentelements {
                 medium = 0.5
             }
             gutters {
-                default = 40
-                xlarge = 40
-                large = 40
-                medium = 40
+                default = 20
+                xlarge = 20
+                large = 20
+                medium = 20
             }
         }
     }

--- a/Configuration/TypoScript/ContentElement/Helper/ContentElement.typoscript
+++ b/Configuration/TypoScript/ContentElement/Helper/ContentElement.typoscript
@@ -101,12 +101,12 @@ lib.contentElement {
                         extrasmall = 0.5
                     }
                     gutters {
-                        default = 8
-                        xlarge = 8
-                        large = 8
-                        medium = 8
-                        small = 8
-                        extrasmall = 8
+                        default = 4
+                        xlarge = 4
+                        large = 4
+                        medium = 4
+                        small = 4
+                        extrasmall = 4
                     }
                 }
                 3 {
@@ -120,12 +120,12 @@ lib.contentElement {
                         extrasmall = 0.3333
                     }
                     gutters {
-                        default = 16
-                        xlarge = 16
-                        large = 16
-                        medium = 16
-                        small = 16
-                        extrasmall = 16
+                        default = 4
+                        xlarge = 4
+                        large = 4
+                        medium = 4
+                        small = 4
+                        extrasmall = 4
                     }
                 }
                 4 {
@@ -139,12 +139,12 @@ lib.contentElement {
                         extrasmall = 0.5
                     }
                     gutters {
-                        default = 24
-                        xlarge = 24
-                        large = 24
-                        medium = 8
-                        small = 8
-                        extrasmall = 8
+                        default = 4
+                        xlarge = 4
+                        large = 4
+                        medium = 4
+                        small = 4
+                        extrasmall = 4
                     }
                 }
                 5 {
@@ -158,12 +158,12 @@ lib.contentElement {
                         extrasmall = 0.5
                     }
                     gutters {
-                        default = 32
-                        xlarge = 32
-                        large = 32
-                        medium = 16
-                        small = 16
-                        extrasmall = 8
+                        default = 4
+                        xlarge = 4
+                        large = 4
+                        medium = 4
+                        small = 4
+                        extrasmall = 4
                     }
                 }
                 6 {
@@ -177,12 +177,12 @@ lib.contentElement {
                         extrasmall = 0.5
                     }
                     gutters {
-                        default = 40
-                        xlarge = 40
-                        large = 40
-                        medium = 16
-                        small = 16
-                        extrasmall = 8
+                        default = 4
+                        xlarge = 4
+                        large = 4
+                        medium = 4
+                        small = 4
+                        extrasmall = 4
                     }
                 }
             }
@@ -191,11 +191,11 @@ lib.contentElement {
             variants {
                 default {
                     breakpoint = 1400
-                    width = 1280
+                    width = 1320
                 }
                 xlarge {
                     breakpoint = 1200
-                    width = 1100
+                    width = 1140
                 }
                 large {
                     breakpoint = 992
@@ -215,6 +215,22 @@ lib.contentElement {
                 }
             }
             backendlayout {
+                default {
+                    0 {
+                        multiplier {
+                            default = 1
+                            xlarge = 1
+                            large = 1
+                        }
+                        gutters {
+                            default = 40
+                            xlarge = 40
+                            large = 40
+                        }
+                    }
+                }
+                none < .default
+                simple < .default
                 2_columns {
                     0 {
                         multiplier {
@@ -371,6 +387,7 @@ lib.contentElement {
                         }
                     }
                 }
+                special_feature < .default
                 special_feature {
                     30 {
                         multiplier {
@@ -501,6 +518,7 @@ lib.contentElement {
                         }
                     }
                 }
+                special_start < .default
                 special_start {
                     20 {
                         multiplier {

--- a/Resources/Private/Templates/ContentElements/Tab.html
+++ b/Resources/Private/Templates/ContentElements/Tab.html
@@ -36,7 +36,7 @@
                             <div class="tab-pane-content-item tab-pane-content-media">
                                 <f:variable name="imageConfig">{settings.responsiveimages.contentelements.tab.{record.data.mediaorient}}</f:variable>
                                 <bk2k:data.imageVariants as="variants" variants="{currentVariants}" multiplier="{imageConfig.multiplier}" gutters="{imageConfig.gutters}" corrections="{imageConfig.corrections}" />
-                                <f:render partial="Media/Gallery" arguments="{files: record.files, data: record.data, settings: settings}" />
+                                <f:render partial="Media/Gallery" arguments="{files: record.files, data: record.data, settings: settings, variants: variants}" />
                             </div>
                         </f:if>
                         <div class="tab-pane-content-item tab-pane-content-text">


### PR DESCRIPTION
# Pull Request

## Related Issues

Fixes #1228

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [X] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [X] Changes have been tested on PHP 8.0
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

### 1) Image sizes are correct now (generated image is same size than displayed image).
Image sizes fit better now because it's **nearer to the styling you use in CSS**:

Example for backend layout "2_columns" (75%/27%). There you have 1320px width, column 1 has 75% width, column 25% and **THEN** you add a padding (gutter) of 40px to both columns. So column 1 is 950px and column 2 is 290px.
But for image generation, you use 1280px width, remove 40px and then 75%/25%. So image in column 1 is 930px (too small!) and image in column 2 is 310px (too big!).

And I fixed gutter settings.

### 2) Bugfix for tab content element

## Steps to Validate

* Read my comments in TypoScript
* Check image sizes with console
