### PR TITLE
[BUGFIX] Render "hidden" fields as `checkboxToggle`

### DIFF
--- a/Configuration/TCA/tx_bootstrappackage_accordion_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_accordion_item.php
@@ -100,6 +100,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'

--- a/Configuration/TCA/tx_bootstrappackage_card_group_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_card_group_item.php
@@ -113,6 +113,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'

--- a/Configuration/TCA/tx_bootstrappackage_carousel_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_carousel_item.php
@@ -289,6 +289,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'

--- a/Configuration/TCA/tx_bootstrappackage_icon_group_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_icon_group_item.php
@@ -95,6 +95,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'

--- a/Configuration/TCA/tx_bootstrappackage_tab_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_tab_item.php
@@ -100,6 +100,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'

--- a/Configuration/TCA/tx_bootstrappackage_timeline_item.php
+++ b/Configuration/TCA/tx_bootstrappackage_timeline_item.php
@@ -96,6 +96,7 @@ return [
             'label' => 'LLL:EXT:core/Resources/Private/Language/locallang_general.xlf:LGL.hidden',
             'config' => [
                 'type' => 'check',
+                'renderType' => 'checkboxToggle',
                 'items' => [
                     '1' => [
                         '0' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:hidden.I.0'


### PR DESCRIPTION
"Item" records provided by EXT:bootstrap_package (e.g. for accordion, carousel, etc.) are usually rendered in IRRE contexts. There is a wild bug if an element is disabled ("hidden") that makes it very hard to enable it again.

The root cause is that checkbox fields are internally handled as bitmasks, triggering a strange behavior as an enabled checkbox is rendered as disabled as long the element is disabled.

To overcome this issue until TYPO3 Core's behavior is fixed, "hidden" fields are now rendered as `checkboxToggle` that don't trigger the bug.