### PR TITLE
[TASK] Adds back the toolbar for tables, which was dropped from the s…

### DIFF
--- a/Configuration/RTE/Default.yaml
+++ b/Configuration/RTE/Default.yaml
@@ -18,7 +18,14 @@ editor:
 
     config:
         contentsCss: "EXT:bootstrap_package/Resources/Public/Css/bootstrap5-rte.min.css"
-
+        table:
+          contentToolbar:
+          - "tableColumn"
+          - "tableRow"
+          - "mergeTableCells"
+          - "tableProperties"
+          - "tableCellProperties"
+          - "toggleTableCaption"
         stylesSet:
             - { name: "Lead", element: "p", attributes: { 'class': 'lead' } }
             - { name: "Small", element: "small" }


### PR DESCRIPTION
…witch from ckeditor v4 to v5 (TYPO3 12.x)

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [x ] Changes have been tested on TYPO3 v12.2
* [ ] Changes have been tested on PHP 7.2
* [ ] Changes have been tested on PHP 7.3
* [ ] Changes have been tested on PHP 7.4
* [x ] Changes have been tested on PHP 8.0
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. open RTE
2. creating Table
3. selecting cell
4. Table toolbar pops up
