### PR TITLE
Add Fluid templates for EXT:felogin

### DIFF
--- a/Configuration/TypoScript/Extension/Felogin/constants.typoscript
+++ b/Configuration/TypoScript/Extension/Felogin/constants.typoscript
@@ -2,5 +2,10 @@
 #### FRONTEND LOGIN ####
 ########################
 styles.content.loginform {
-    templateFile = EXT:bootstrap_package/Resources/Private/Templates/Felogin/FrontendLogin.html
+    view {
+        layoutRootPath = EXT:bootstrap_package/Resources/Private/Layouts/Felogin/
+        partialRootPath = EXT:bootstrap_package/Resources/Private/Partials/Felogin/
+        templateRootPath = EXT:bootstrap_package/Resources/Private/Templates/Felogin/
+    }
+    templateFile = EXT:bootstrap_package/Resources/Private/Templates/Felogin/Login/Login.html
 }

--- a/Configuration/TypoScript/Extension/Felogin/setup.typoscript
+++ b/Configuration/TypoScript/Extension/Felogin/setup.typoscript
@@ -1,19 +1,16 @@
 ########################
 #### FRONTEND LOGIN ####
 ########################
-plugin.tx_felogin_pi1 {
-    wrapContentInBaseClass = 0
-    welcomeMessage_stdWrap.wrap = <p>|</p>
-    logoutMessage_stdWrap.wrap = <p>|</p>
-    errorMessage_stdWrap.wrap = <p class="text-danger">|</p>
-    successMessage_stdWrap.wrap = <p class="text-success">|</p>
-    cookieWarning_stdWrap.wrap = <p class="text-warning">|</p>
-    forgotMessage_stdWrap.wrap = <p>|</p>
-    forgotErrorMessage_stdWrap.wrap = <p class="text-danger">|</p>
-    forgotResetMessageEmailSentMessage_stdWrap.wrap = <p class="text-success">|</p>
-    changePasswordNotValidMessage_stdWrap.wrap = <p class="text-danger">|</p>
-    changePasswordTooShortMessage_stdWrap.wrap = <p class="text-danger">|</p>
-    changePasswordNotEqualMessage_stdWrap.wrap = <p class="text-danger">|</p>
-    changePasswordMessage_stdWrap.wrap = <p>|</p>
-    changePasswordDoneMessage_stdWrap.wrap = <p class="text-success">|</p>
+plugin.tx_felogin_login {
+    view {
+        layoutRootPaths {
+            10 = {$styles.content.loginform.view.layoutRootPath}
+        }
+        partialRootPaths {
+            10 = {$styles.content.loginform.view.partialRootPath}
+        }
+        templateRootPaths {
+            10 = {$styles.content.loginform.view.templateRootPath}
+        }
+    }
 }

--- a/Resources/Private/Partials/Felogin/CookieWarning.html
+++ b/Resources/Private/Partials/Felogin/CookieWarning.html
@@ -1,0 +1,5 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<p class="text-warning"><f:translate key="cookie_warning" /></p>
+
+</html>

--- a/Resources/Private/Templates/Felogin/Login/Login.html
+++ b/Resources/Private/Templates/Felogin/Login/Login.html
@@ -1,0 +1,91 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<f:flashMessages />
+<f:if condition="{cookieWarning}">
+    <f:render partial="CookieWarning" />
+</f:if>
+
+<f:if condition="{messageKey}">
+    <h3>
+        <f:render partial="RenderLabelOrMessage" arguments="{key: '{messageKey}_header'}" />
+    </h3>
+    <p{f:if(condition: '{messageKey} == "error"', then: ' class="text-danger"')}>
+        <f:render partial="RenderLabelOrMessage" arguments="{key: '{messageKey}_message'}" />
+    </p>
+</f:if>
+<f:if condition="{onSubmit}">
+    <f:then>
+        <f:form target="_top" fieldNamePrefix="" action="login" onsubmit="{onSubmit}">
+            <f:render section="content" arguments="{_all}" />
+        </f:form>
+    </f:then>
+    <f:else>
+        <f:form target="_top" fieldNamePrefix="" action="login">
+            <f:render section="content" arguments="{_all}" />
+        </f:form>
+    </f:else>
+</f:if>
+
+<f:if condition="{settings.showForgotPassword}">
+    <f:link.action action="recovery" controller="PasswordRecovery">
+        <f:render partial="RenderLabelOrMessage" arguments="{key: 'forgot_header'}" />
+    </f:link.action>
+</f:if>
+
+<f:section name="content">
+    <fieldset>
+        <legend><f:translate key="login" /></legend>
+        <div class="form-group">
+            <label for="user"><f:translate key="username" /></label>
+            <f:form.textfield name="user" class="form-control" required="true" additionalAttributes="{autocomplete: 'username'}" />
+        </div>
+        <div class="form-group">
+            <label for="pass"><f:translate key="password" /></label>
+            <f:form.password name="pass" class="form-control" data="{rsa-encryption: ''}" additionalAttributes="{required: 'required', autocomplete: 'current-password'}" />
+        </div>
+
+        <f:if condition="{permaloginStatus} > -1">
+            <div class="form-group">
+                <div class="checkbox">
+                    <label for="permalogin">
+                        <f:if condition="{permaloginStatus} == 1">
+                            <f:then>
+                                <f:form.hidden name="permalogin" value="0" additionalAttributes="{disabled: 'disabled'}" />
+                                <f:form.checkbox name="permalogin" id="permalogin" value="1" checked="checked" />
+                            </f:then>
+                            <f:else>
+                                <f:form.hidden name="permalogin" value="0" />
+                                <f:form.checkbox name="permalogin" id="permalogin" value="1" />
+                            </f:else>
+                        </f:if>
+                        <f:translate id="permalogin" />
+                    </label>
+                </div>
+            </div>
+        </f:if>
+
+        <div class="form-group">
+            <f:form.submit name="submit" class="btn btn-primary" value="{f:translate(key: 'login')}" />
+        </div>
+
+        <div class="felogin-hidden">
+            <f:form.hidden name="logintype" value="login" />
+            <f:form.hidden name="pid" value="{storagePid}" />
+            <f:if condition="{redirectURL}!=''">
+                <f:form.hidden name="redirect_url" value="{redirectURL}" />
+            </f:if>
+            <f:if condition="{referer}!=''">
+                <f:form.hidden name="referer" value="{referer}" />
+            </f:if>
+            <f:if condition="{redirectReferrer}!=''">
+                <f:form.hidden name="redirectReferrer" value="off" />
+            </f:if>
+            <f:if condition="{noRedirect}!=''">
+                <f:form.hidden name="noredirect" value="1" />
+            </f:if>
+
+            {extraHidden}
+        </div>
+    </fieldset>
+</f:section>
+</html>

--- a/Resources/Private/Templates/Felogin/Login/Logout.html
+++ b/Resources/Private/Templates/Felogin/Login/Logout.html
@@ -1,0 +1,31 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+
+<f:if condition="{cookieWarning}">
+    <f:render partial="CookieWarning" />
+</f:if>
+
+<h3>
+    <f:render partial="RenderLabelOrMessage" arguments="{key: 'status_header'}" />
+</h3>
+<p>
+    <f:render partial="RenderLabelOrMessage" arguments="{key: 'status_message'}" />
+</p>
+
+<f:form action="login" actionUri="{actionUri}" target="_top" fieldNamePrefix="">
+    <fieldset>
+        <legend><f:translate key="logout" /></legend>
+        <dl>
+            <dt><f:translate key="username" /></dt>
+            <dd>{user.username}</dd>
+        </dl>
+        <div class="form-group">
+            <f:form.submit name="submit" class="btn btn-primary" value="{f:translate(key: 'logout')}" />
+        </div>
+
+        <div class="felogin-hidden">
+            <f:form.hidden name="logintype" value="logout" />
+            <f:form.hidden name="pid" value="{storagePid}" />
+        </div>
+    </fieldset>
+</f:form>
+</html>

--- a/Resources/Private/Templates/Felogin/PasswordRecovery/Recovery.html
+++ b/Resources/Private/Templates/Felogin/PasswordRecovery/Recovery.html
@@ -1,0 +1,29 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<h3>
+    <f:render partial="RenderLabelOrMessage" arguments="{key: 'forgot_header'}" />
+</h3>
+<p>
+    <f:render partial="RenderLabelOrMessage" arguments="{key: 'forgot_reset_message'}" />
+</p>
+
+<f:render partial="ValidationErrors" />
+
+<f:form action="recovery" method="post">
+    <fieldset>
+        <legend><f:render partial="RenderLabelOrMessage" arguments="{key: 'reset_password'}" /></legend>
+        <div class="form-group">
+            <label for="userIdentifier"><f:translate key="enter_your_data" /></label>
+            <f:form.textfield name="userIdentifier" class="form-control" />
+        </div>
+        <div class="form-group">
+            <f:form.submit class="btn btn-primary" value="{f:translate(key: 'reset_password')}" />
+        </div>
+    </fieldset>
+</f:form>
+
+<p>
+    <f:link.action action="login" controller="Login">
+        <f:translate key="forgot_header_backToLogin" />
+    </f:link.action>
+</p>
+</html>

--- a/Resources/Private/Templates/Felogin/PasswordRecovery/ShowChangePassword.html
+++ b/Resources/Private/Templates/Felogin/PasswordRecovery/ShowChangePassword.html
@@ -1,0 +1,32 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<h3>
+    <f:translate key="change_password_header" />
+</h3>
+<p>
+    <f:translate key="change_password_message" arguments="{0: settings.newPasswordMinLength}" />
+</p>
+
+<f:render partial="ValidationErrors" />
+
+<f:form action="changePassword" method="post">
+    <legend><f:translate key="change_password" /></legend>
+    <div class="form-group">
+        <label for="newPass"><f:translate key="newpassword_label1" /></label>
+        <f:form.password name="newPass" class="form-control" additionalAttributes="{autocomplete: 'new-password'}" />
+    </div>
+    <div class="form-group">
+        <label for="newPassRepeat"><f:translate key="newpassword_label2" /></label>
+        <f:form.password name="newPassRepeat" class="form-control" additionalAttributes="{autocomplete: 'new-password'}" />
+    </div>
+    <div class="form-group">
+        <f:form.submit class="btn btn-primary" value="{f:translate(key: 'change_password')}" />
+    </div>
+    <f:form.hidden name="hash" value="{hash}" />
+</f:form>
+
+<p>
+    <f:link.action action="login" controller="Login">
+        <f:translate key="forgot_header_backToLogin" />
+    </f:link.action>
+</p>
+</html>


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1223
* Resolves #1189

## Prerequisites

* [x] Changes have been tested on TYPO3 v10.4 LTS
* [ ] Changes have been tested on TYPO3 v11.5 LTS

## Description

As EXT:felogin is available as Extbase plugin using Fluid templates since Typo3 v10.2 (https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/10.2/Feature-88102-FrontendLoginViaFluidAndExtbase.html) EXT:bootstrap_package should provide templates for it. The templates are based on the old one for the PiBase plugin. 

## Steps to Validate

1. Activate feature toggle "Felogin: extbase"
2. Add login plugin to website
