### PR TITLE
Fix multiplier value float type being transformed to integer.

### DIFF
--- a/Classes/Utility/ImageVariantsUtility.php
+++ b/Classes/Utility/ImageVariantsUtility.php
@@ -114,7 +114,6 @@ class ImageVariantsUtility
             ) {
                 continue;
             }
-            $settings['multiplier'] = gettype($settings['multiplier']) === 'double' ? $settings['multiplier'] : (int) $settings['multiplier'];
             $workingSizes[substr($key, 0, -1) . ''] = [
                 'multiplier' => 1 * $settings['multiplier'],
             ];


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes  #1261  [bug]

## Prerequisites

* [x] Changes have been tested on TYPO3 v10.4 LTS
* [x] Changes have been tested on TYPO3 v11.5 LTS

## Description

On Versions 12 and 13: Remove line 117 from ImageVariantsUtility.php, the line 119 is already casting the multiplier value to the correct type.

Both versions above have the same line and can be removed:
$settings['multiplier'] = gettype($settings['multiplier']) === 'double' ? $settings['multiplier'] : (int) $settings['multiplier'];

## Steps to validate

1. Add a TypoScript setup as shown in the [documentation](https://docs.typo3.org/p/bk2k/bootstrap-package/main/en-us/Configuration/ImageRendering/Index.html#high-resolution-images) (inlined for brevity):
`lib.contentElement.settings.responsiveimages.variants.default.sizes.1\.5x.multiplier = 1.5`

2. Add an image element to any webpage. You can skip this if you already have an image element to check.

3. Inspect the image source code in the Frontend. The `srcset` parameter will have references to two images (or more if you have more multipliers), one that ends with 1x and another with 1.5x. The URLs should be different.
