### PR TITLE
[TASK] Add aria-hidden attributes for decorative icons

### DIFF
--- a/Classes/Icons/FileIcon.php
+++ b/Classes/Icons/FileIcon.php
@@ -66,7 +66,7 @@ class FileIcon extends AbstractIcon
             $processedImage = $imageService->applyProcessingInstructions($image, $processingInstructions);
             $imageUri = $imageService->getImageUri($processedImage);
 
-            return '<img loading="lazy" src="' . $imageUri . '" height="' . $height . '" width="' . $width . '" />';
+            return '<img loading="lazy" src="' . $imageUri . '" height="' . $height . '" width="' . $width . '" aria-hidden="true" />';
         } catch (ResourceDoesNotExistException $e) {
             // thrown if file does not exist
             throw new \Exception($e->getMessage(), 1628773040, $e);

--- a/Classes/Utility/SvgUtility.php
+++ b/Classes/Utility/SvgUtility.php
@@ -74,6 +74,7 @@ class SvgUtility
             $svgElement = self::setAttribute($svgElement, 'width', $width);
             $height = intval($height) > 0 ? (string) intval($height) : null;
             $svgElement = self::setAttribute($svgElement, 'height', $height);
+            $svgElement = self::setAttribute($svgElement, 'aria-hidden', 'true');
 
             // remove xml version tag
             $domXml = dom_import_simplexml($svgElement);


### PR DESCRIPTION
Related: #1278

# Pull Request

## Related Issues

* Fixes #1278

## Prerequisites

* [ ] Changes have been tested on TYPO3 v12.5 LTS
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

More Doc here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden

@benjaminkott and @alboth decided that all ICONs on the can be interpreted as purely decorative content. 
Therefor they all deserve a ``¸`aria-hidden="true"`

It is fixed for 

- Fileicons (png, svg)
- Ionicons & Glypicons (using SvgUtility)

In my opinion we could still debate/think about the bootstrap icon-font. The `[::before](bootstrappackageicon::before)` have no css `speak: none` property.  

## Steps to Validate

1. co branch 1278-aria-hidden-for-decorative-images
2. visit in ticket mentioned urls - https://github.com/benjaminkott/bootstrap_package/issues/1278
3. check that other images DO NOT get the `aria-hidden` attribute

