### PR TITLE
[TASK] Switched forms template variant to version2

### DIFF
--- a/Configuration/Form/Setup.yaml
+++ b/Configuration/Form/Setup.yaml
@@ -9,6 +9,7 @@ TYPO3:
                     formElementsDefinition:
                         Form:
                             renderingOptions:
+                                templateVariant: version2
                                 translation:
                                     translationFiles:
                                         110: 'EXT:bootstrap_package/Resources/Private/Language/locallang.xlf'


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1313

## Prerequisites

* [x] Changes have been tested on TYPO3 v11.5 LTS
* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1.16

## Description
TASK: Remove roles "group" and "toolbar" from contact form submit button.
SOLUTION: Switch to new form templates ("version2") which do not contain these roles in the markup

see: https://forge.typo3.org/issues/95456

## Steps to Validate
1. Add predefined contact form to any page
2. Check form markup in frontend