### PR TITLE
[BUGFIX] Fix missing spaces in the output of content elements

### DIFF
--- a/Resources/Private/Layouts/ContentElements/Default.html
+++ b/Resources/Private/Layouts/ContentElements/Default.html
@@ -1,45 +1,41 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:spaceless>
+<bk2k:data.imageVariants as="variants" variants="{settings.responsiveimages.variants}" />
+<f:variable name="backendlayoutConfig">{settings.responsiveimages.backendlayout.{backendlayout}}</f:variable>
+<f:variable name="columnConfig">{backendlayoutConfig.{data.colPos}}</f:variable>
+<f:if condition="{columnConfig}">
+    <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{columnConfig.multiplier}" gutters="{columnConfig.gutters}" corrections="{columnConfig.corrections}" />
+</f:if>
 
-    <bk2k:data.imageVariants as="variants" variants="{settings.responsiveimages.variants}" />
-    <f:variable name="backendlayoutConfig">{settings.responsiveimages.backendlayout.{backendlayout}}</f:variable>
-    <f:variable name="columnConfig">{backendlayoutConfig.{data.colPos}}</f:variable>
-    <f:if condition="{columnConfig}">
-        <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{columnConfig.multiplier}" gutters="{columnConfig.gutters}" corrections="{columnConfig.corrections}" />
-    </f:if>
+<f:if condition="{containerContext}">
+    <f:for each="{containerContext}" as="context">
+        <f:variable name="containerConfig">{settings.responsiveimages.container.{context.CType}}</f:variable>
+        <f:variable name="containerColumnConfig">{containerConfig.{data.colPos}}</f:variable>
+        <f:if condition="{containerColumnConfig}">
+            <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{containerColumnConfig.multiplier}" gutters="{containerColumnConfig.gutters}" corrections="{containerColumnConfig.corrections}" />
+        </f:if>
+    </f:for>
+</f:if>
 
-    <f:if condition="{containerContext}">
-        <f:for each="{containerContext}" as="context">
-            <f:variable name="containerConfig">{settings.responsiveimages.container.{context.CType}}</f:variable>
-            <f:variable name="containerColumnConfig">{containerConfig.{data.colPos}}</f:variable>
-            <f:if condition="{containerColumnConfig}">
-                <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{containerColumnConfig.multiplier}" gutters="{containerColumnConfig.gutters}" corrections="{containerColumnConfig.corrections}" />
-            </f:if>
-        </f:for>
-    </f:if>
-
-    <bk2k:frame
-        id="c{data.uid}"
-        type="{data.CType}"
-        size="default"
-        layout="{data.frame_layout}"
-        frameClass="{data.frame_class}"
-        frameAttributes="{frameAttributes}"
-        spaceBefore="{data.space_before_class}"
-        spaceAfter="{data.space_after_class}"
-        options="{data.frame_options}"
-        variants="{variants}"
-        backgroundColor="{data.background_color_class}"
-        backgroundImage="{backgroundImage.0}"
-        backgroundImageOptions="{data.background_image_options}"
-    >
-        <f:if condition="{data._LOCALIZED_UID}"><a id="c{data._LOCALIZED_UID}"></a></f:if>
-        <f:render section="Before" optional="true"><f:render partial="DropIn/Before/All" arguments="{_all}" /></f:render>
-        <f:render section="Header" optional="true"><f:render partial="Header/All" arguments="{_all}" /></f:render>
-        <f:render section="Main"   optional="true" />
-        <f:render section="Footer" optional="true"><f:render partial="Footer/All" arguments="{_all}" /></f:render>
-        <f:render section="After"  optional="true"><f:render partial="DropIn/After/All" arguments="{_all}" /></f:render>
-    </bk2k:frame>
-
-</f:spaceless>
+<bk2k:frame
+    id="c{data.uid}"
+    type="{data.CType}"
+    size="default"
+    layout="{data.frame_layout}"
+    frameClass="{data.frame_class}"
+    frameAttributes="{frameAttributes}"
+    spaceBefore="{data.space_before_class}"
+    spaceAfter="{data.space_after_class}"
+    options="{data.frame_options}"
+    variants="{variants}"
+    backgroundColor="{data.background_color_class}"
+    backgroundImage="{backgroundImage.0}"
+    backgroundImageOptions="{data.background_image_options}"
+>
+    <f:if condition="{data._LOCALIZED_UID}"><a id="c{data._LOCALIZED_UID}"></a></f:if>
+    <f:render section="Before" optional="true"><f:render partial="DropIn/Before/All" arguments="{_all}" /></f:render>
+    <f:render section="Header" optional="true"><f:render partial="Header/All" arguments="{_all}" /></f:render>
+    <f:render section="Main"   optional="true" />
+    <f:render section="Footer" optional="true"><f:render partial="Footer/All" arguments="{_all}" /></f:render>
+    <f:render section="After"  optional="true"><f:render partial="DropIn/After/All" arguments="{_all}" /></f:render>
+</bk2k:frame>
 </html>

--- a/Resources/Private/Layouts/Page/Default.html
+++ b/Resources/Private/Layouts/Page/Default.html
@@ -1,5 +1,4 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:spaceless>
 <div id="top"></div>
 <div class="body-bg{f:if(condition:theme.navigation.type, then:' body-bg-{theme.navigation.type}')}">
 
@@ -28,5 +27,4 @@
     <f:render partial="DropIn/Page/PageAfter" arguments="{_all}" />
 
 </div>
-</f:spaceless>
 </html>

--- a/Resources/Private/Templates/ViewHelpers/Frame/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Frame/Index.html
@@ -1,4 +1,3 @@
-<f:spaceless>
 <f:if condition="{configuration.displayFrame}">
     <f:then>
         <div {frameAttributes -> f:format.raw()}>
@@ -28,4 +27,3 @@
 
     </f:else>
 </f:if>
-</f:spaceless>


### PR DESCRIPTION
# Pull Request

## Prerequisites
* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

The spaceless-ViewHelper also remove spaces between inline elements and thus the spacing between these elements. By removing the ViewHelper, the output is again as expected.

## Steps to Validate

1. Insert 2 links in the RTE with e.g. "btn btn-primary"
2. Open the frontend
3. The space between the buttons is removed with <f:spaceless> in the frontend
