### PR TITLE
[TASK] duplicate css class removed

### DIFF
--- a/Resources/Private/Templates/ContentElements/MenuCardDir.html
+++ b/Resources/Private/Templates/ContentElements/MenuCardDir.html
@@ -6,7 +6,7 @@
         <f:variable name="imageConfig">{settings.responsiveimages.contentelements.menu_card_dir.{data.pi_flexform.columns}}</f:variable>
         <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{imageConfig.multiplier}" gutters="{imageConfig.gutters}" corrections="{imageConfig.corrections}" />
         <f:render partial="Menu/SkipNavigation" arguments="{_all}" />
-        <div class="card-menu card-menu card-menu-align-{data.pi_flexform.align} card-menu-columns-{data.pi_flexform.columns}">
+        <div class="card-menu card-menu-align-{data.pi_flexform.align} card-menu-columns-{data.pi_flexform.columns}">
             <f:for each="{menu}" as="page">
                 <div class="card-menu-item">
 

--- a/Resources/Private/Templates/ContentElements/MenuCardList.html
+++ b/Resources/Private/Templates/ContentElements/MenuCardList.html
@@ -6,7 +6,7 @@
         <f:variable name="imageConfig">{settings.responsiveimages.contentelements.menu_card_list.{data.pi_flexform.columns}}</f:variable>
         <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{imageConfig.multiplier}" gutters="{imageConfig.gutters}" corrections="{imageConfig.corrections}" />
         <f:render partial="Menu/SkipNavigation" arguments="{_all}" />
-        <div class="card-menu card-menu card-menu-align-{data.pi_flexform.align} card-menu-columns-{data.pi_flexform.columns}">
+        <div class="card-menu card-menu-align-{data.pi_flexform.align} card-menu-columns-{data.pi_flexform.columns}">
             <f:for each="{menu}" as="page">
                 <div class="card-menu-item">
 


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [x ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

duplicate css "card-menu" class removed in MenuCardDir.html and MenuCardList.html

## Steps to Validate

have a look an line 9 in MenuCardDir.html and MenuCardList.html
https://github.com/benjaminkott/bootstrap_package/blob/e61fdea22313198b472abe37f459ba23d7b07340/Resources/Private/Templates/ContentElements/MenuCardList.html#L9
https://github.com/benjaminkott/bootstrap_package/blob/e61fdea22313198b472abe37f459ba23d7b07340/Resources/Private/Templates/ContentElements/MenuCardDir.html#L9

Best Regards
Sven
