### PR TITLE
[TASK] Move extended search field tx_indexedsearch_ext out of input g…

### DIFF
--- a/Resources/Private/Partials/IndexedSearch/Form.html
+++ b/Resources/Private/Partials/IndexedSearch/Form.html
@@ -130,15 +130,15 @@
                     <label for="tx-indexedsearch-selectbox-group" class="control-label">
                         <f:translate key="form.style" />
                     </label>
-                    <div class="input-group">
-                        <f:form.select name="search[group]" options="{allGroups}" value="{searchParams.group}" id="tx-indexedsearch-selectbox-group" class="form-control" />
-                        <f:if condition="{settings.blind.extResume} == 0">
-                            <span class="input-group-addon">
-                                <f:form.checkbox name="search[extResume]" id="tx_indexedsearch_extResume" checked="{searchParams.extResume}" value="1" />
-                            </span>
-                        </f:if>
-                    </div>
+                    <f:form.select name="search[group]" options="{allGroups}" value="{searchParams.group}" id="tx-indexedsearch-selectbox-group" class="form-control" />
                 </div>
+            </f:if>
+            <f:if condition="{settings.blind.extResume} == 0">
+                <div class="form-group">
+                    <label for="tx_indexedsearch_extResume" class="control-label">
+                        <f:translate key="form.extResume" />
+                    </label>
+                    <f:form.checkbox name="search[extResume]" id="tx_indexedsearch_extResume" checked="{searchParams.extResume}" value="1" />
             </f:if>
         </f:if>
     </fieldset>


### PR DESCRIPTION
…roup and assign a label to it

# Pull Request

## Related Issues

* Fixes #1321

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Problem:
The extended search checkbox `tx_indexedsearch_ext` seems to have no function. There is also no label.

Solution:
Till the checkbox actually has a function it should be displayed nicely.
- moved checkbox `tx_indexedsearch_ext` out of input group
- assigned a label to it

## Steps to Validate

1. Open the advanced search form in the frontend
2. Check markup of the checkbox "Extended resume" at the end of the advanced search form