### PR TITLE
[TASK] replaced the main tag in page templates with div tag and add r…

### DIFF
--- a/Resources/Private/Templates/Page/2Columns.html
+++ b/Resources/Private/Templates/Page/2Columns.html
@@ -12,9 +12,9 @@
     <div class="section section-default">
         <div class="container">
             <div class="section-row">
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', slide: '{theme.pagelayout.{pagelayout}.colPos.2.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/2Columns2575.html
+++ b/Resources/Private/Templates/Page/2Columns2575.html
@@ -12,9 +12,9 @@
     <div class="section section-default">
         <div class="container">
             <div class="section-row">
-                <main class="section-column maincontent-wrap" >
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', slide: '{theme.pagelayout.{pagelayout}.colPos.1.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/2Columns5050.html
+++ b/Resources/Private/Templates/Page/2Columns5050.html
@@ -12,9 +12,9 @@
     <div class="section section-default">
         <div class="container">
             <div class="section-row">
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', slide: '{theme.pagelayout.{pagelayout}.colPos.2.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/2ColumnsOffsetRight.html
+++ b/Resources/Private/Templates/Page/2ColumnsOffsetRight.html
@@ -12,9 +12,9 @@
     <div class="section section-default">
         <div class="container">
             <div class="section-row">
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', slide: '{theme.pagelayout.{pagelayout}.colPos.2.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/3Columns.html
+++ b/Resources/Private/Templates/Page/3Columns.html
@@ -12,9 +12,9 @@
     <div class="section section-default">
         <div class="container">
             <div class="section-row">
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', slide: '{theme.pagelayout.{pagelayout}.colPos.1.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/Default.html
+++ b/Resources/Private/Templates/Page/Default.html
@@ -9,7 +9,7 @@
 
     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '8', slide: '{theme.pagelayout.{pagelayout}.colPos.8.slide}'}" />
 
-    <div class="section section-default">
+    <div class="section section-default" role="main">
         <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
     </div>
 

--- a/Resources/Private/Templates/Page/Simple.html
+++ b/Resources/Private/Templates/Page/Simple.html
@@ -9,7 +9,7 @@
 
     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '8', slide: '{theme.pagelayout.{pagelayout}.colPos.8.slide}'}" />
 
-    <div class="section section-default">
+    <div class="section section-default" role="main">
         <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
     </div>
 

--- a/Resources/Private/Templates/Page/SpecialFeature.html
+++ b/Resources/Private/Templates/Page/SpecialFeature.html
@@ -9,7 +9,7 @@
 
     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '8', slide: '{theme.pagelayout.{pagelayout}.colPos.8.slide}'}" />
 
-    <div class="section section-default">
+    <div class="section section-default" role="main">
         <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
     </div>
 

--- a/Resources/Private/Templates/Page/SpecialStart.html
+++ b/Resources/Private/Templates/Page/SpecialStart.html
@@ -24,7 +24,7 @@
             </div>
         </div>
     </div>
-    <div class="section section-light">
+    <div class="section section-light" role="main">
         <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
     </div>
 

--- a/Resources/Private/Templates/Page/SubnavigationLeft.html
+++ b/Resources/Private/Templates/Page/SubnavigationLeft.html
@@ -15,9 +15,9 @@
                 <div class="section-column subnav-wrap">
                     <f:render partial="Navigation/Subnavigation" arguments="{_all}" />
                 </div>
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
             </div>
         </div>
     </div>

--- a/Resources/Private/Templates/Page/SubnavigationLeft2Columns.html
+++ b/Resources/Private/Templates/Page/SubnavigationLeft2Columns.html
@@ -15,9 +15,9 @@
                 <div class="section-column subnav-wrap">
                     <f:render partial="Navigation/Subnavigation" arguments="{_all}" />
                 </div>
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '1', slide: '{theme.pagelayout.{pagelayout}.colPos.1.slide}'}" />
                 </div>

--- a/Resources/Private/Templates/Page/SubnavigationRight.html
+++ b/Resources/Private/Templates/Page/SubnavigationRight.html
@@ -15,9 +15,9 @@
                 <div class="section-column subnav-wrap">
                     <f:render partial="Navigation/Subnavigation" arguments="{_all}" />
                 </div>
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
             </div>
         </div>
     </div>

--- a/Resources/Private/Templates/Page/SubnavigationRight2Columns.html
+++ b/Resources/Private/Templates/Page/SubnavigationRight2Columns.html
@@ -15,9 +15,9 @@
                 <div class="section-column subnav-wrap">
                     <f:render partial="Navigation/Subnavigation" arguments="{_all}" />
                 </div>
-                <main class="section-column maincontent-wrap">
+                <div class="section-column maincontent-wrap" role="main">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '0', slide: '{theme.pagelayout.{pagelayout}.colPos.0.slide}'}" />
-                </main>
+                </div>
                 <div class="section-column subcontent-wrap">
                     <f:cObject typoscriptObjectPath="lib.dynamicContent" data="{pageUid: '{data.uid}', colPos: '2', slide: '{theme.pagelayout.{pagelayout}.colPos.2.slide}'}" />
                 </div>


### PR DESCRIPTION
# Pull Request

Resolves: #1293

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Replaced main tag with div tag and used role main instead. In the places where the main tag for column 0 was missing, I also added role main.

## Steps to Validate

1. Create content element in column 0
2. View content element in frontend
3. Content element should be wrapped in a div tag with role="main"
