### PR TITLE
[TASK] replace nav tag with div tag in custom element tab

### DIFF
--- a/Resources/Private/Templates/ContentElements/Tab.html
+++ b/Resources/Private/Templates/ContentElements/Tab.html
@@ -14,7 +14,7 @@
         <f:variable name="currentVariants" value="{variants}" />
 
 
-        <nav class="tab-navigation">
+        <div class="tab-navigation">
             <div class="nav nav-tabs" id="tab-{data.uid}" role="tablist">
                 <f:for each="{records}" as="record" iteration="iteration">
                     <button class="nav-link{f:if(condition: '{activeTab} == {record.data.uid}',then: ' active')}" id="tab-{data.uid}-{record.data.uid}" data-bs-toggle="tab" data-bs-target="#tabcontent-{data.uid}-{record.data.uid}" type="button" role="tab" aria-controls="tabcontent-{data.uid}-{record.data.uid}" aria-selected="{f:if(condition: '{activeTab} == {record.data.uid}',then: 'true', else: 'false')}">
@@ -22,7 +22,7 @@
                     </button>
                 </f:for>
             </div>
-        </nav>
+        </div>
 
 
 


### PR DESCRIPTION
# Pull Request

## Related Issues

* Resolves #1295

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Replace nav tag with div tag in Template CustomElements/Tab.html

## Steps to Validate

1. Go to page https://bitv-v12.live.typo3.cps.321.works/content-examples/interactive/tab
2. Check that the tab menu no longer contains a nav tag
