### PR TITLE
[TASK] Add meaningful label to each second field in a group in extend…

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -105,6 +105,16 @@
                 <source>Summary</source>
             </trans-unit>
 
+            <trans-unit id="searchForm.element.defaultOperand.label">
+                <source>Match in</source>
+            </trans-unit>
+            <trans-unit id="searchForm.element.language.label">
+                <source>Language</source>
+            </trans-unit>
+            <trans-unit id="searchForm.element.sortDesc.label">
+                <source>Show in order</source>
+            </trans-unit>
+
             <trans-unit id="cookieconsent.common.header">
                 <source>Cookies used on the website!</source>
             </trans-unit>

--- a/Resources/Private/Partials/IndexedSearch/Form.html
+++ b/Resources/Private/Partials/IndexedSearch/Form.html
@@ -50,17 +50,20 @@
         <f:if condition="{searchParams.extendedSearch}">
             <f:if condition="{showTypeSearch}">
                 <div class="form-group">
-                    <label for="tx-indexedsearch-selectbox-searchtype" class="control-label">
-                        <f:translate key="form.match" />
-                    </label>
                     <div class="row">
                         <f:if condition="{allSearchTypes}">
                             <div class="col-sm-6 col-xs-12">
+                                <label for="tx-indexedsearch-selectbox-searchtype" class="control-label">
+                                    <f:translate key="form.match" />
+                                </label>
                                 <f:form.select name="search[searchType]" options="{allSearchTypes}" value="{searchParams.searchType}" id="tx-indexedsearch-selectbox-searchtype" class="form-control" />
                             </div>
                         </f:if>
                         <f:if condition="{allDefaultOperands}">
                             <div class="col-sm-6 col-xs-12">
+                                <label for="tx-indexedsearch-selectbox-defaultoperand" class="control-label">
+                                    <f:translate key="searchForm.element.defaultOperand.label" extensionName="bootstrap_package" />
+                                </label>
                                 <f:form.select name="search[defaultOperand]" options="{allDefaultOperands}" value="{searchParams.defaultOperand}" id="tx-indexedsearch-selectbox-defaultoperand" class="form-control" />
                             </div>
                         </f:if>
@@ -69,17 +72,20 @@
             </f:if>
             <f:if condition="{showMediaAndLanguageSearch}">
                 <div class="form-group">
-                    <label for="tx-indexedsearch-selectbox-media" class="control-label">
-                        <f:translate key="form.searchIn" />
-                    </label>
                     <div class="row">
                         <f:if condition="{allMediaTypes}">
                             <div class="col-sm-6 col-xs-12">
+                                <label for="tx-indexedsearch-selectbox-media" class="control-label">
+                                    <f:translate key="form.searchIn" />
+                                </label>
                                 <f:form.select name="search[mediaType]" options="{allMediaTypes}" value="{searchParams.mediaType}" id="tx-indexedsearch-selectbox-media" class="form-control" />
                             </div>
                         </f:if>
                         <f:if condition="{allLanguageUids}">
                             <div class="col-sm-6 col-xs-12">
+                                <label for="tx-indexedsearch-selectbox-lang" class="control-label">
+                                    <f:translate key="searchForm.element.language.label" extensionName="bootstrap_package" />
+                                </label>
                                 <f:form.select name="search[languageUid]" options="{allLanguageUids}" value="{searchParams.languageUid}" id="tx-indexedsearch-selectbox-lang" class="form-control" />
                             </div>
                         </f:if>
@@ -104,14 +110,17 @@
             </f:if>
             <f:if condition="{showSortOrders}">
                 <div class="form-group">
-                    <label for="tx-indexedsearch-selectbox-order" class="control-label">
-                        <f:translate key="form.orderBy" />
-                    </label>
                     <div class="row">
                         <div class="col-sm-6 col-xs-12">
+                            <label for="tx-indexedsearch-selectbox-order" class="control-label">
+                                <f:translate key="form.orderBy" />
+                            </label>
                             <f:form.select name="search[sortOrder]" options="{allSortOrders}" value="{searchParams.sortOrder}" id="tx-indexedsearch-selectbox-order" class="form-control" />
                         </div>
                         <div class="col-sm-6 col-xs-12">
+                            <label for="tx-indexedsearch-selectbox-desc" class="control-label">
+                                <f:translate key="searchForm.element.sortDesc.label" extensionName="bootstrap_package" />
+                            </label>
                             <f:form.select name="search[sortDesc]"  options="{allSortDescendings}" value="{searchParams.sortDesc}" id="tx-indexedsearch-selectbox-desc" class="form-control" />
                         </div>
                     </div>


### PR DESCRIPTION
…ed search form

# Pull Request

## Related Issues

* Resolves #1312

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Problem:
If form fields are grouped, every field needs his own label. Otherwise the purpose of the second field can be unclear.

Solution:
Add meaningful label to each second field in a group.

## Steps to Validate

1. Open the advanced search form in the frontend
2. Check markup of form groups in the advanced search form
