### PR TITLE
[BUGFIX] Source mapping is now public path agnostic

### DIFF
--- a/Classes/Parser/AbstractParser.php
+++ b/Classes/Parser/AbstractParser.php
@@ -102,6 +102,15 @@ abstract class AbstractParser implements ParserInterface
     }
 
     /**
+     * @param string $filename
+     * @return string
+     */
+    protected function getCacheFileMap(string $filename)
+    {
+        return $filename . '.map';
+    }
+
+    /**
      * @param string $file
      * @param array $settings
      * @return string

--- a/Classes/Parser/ScssParser.php
+++ b/Classes/Parser/ScssParser.php
@@ -65,7 +65,7 @@ class ScssParser extends AbstractParser
                 // Write css file and append reference to source map file
                 GeneralUtility::writeFile(
                     GeneralUtility::getFileAbsFileName($cacheFile),
-                    sprintf("%s /*# sourceMappingURL=%s */", $result['css'], basename($cacheFileMap))
+                    sprintf('%s /*# sourceMappingURL=%s */', $result['css'], basename($cacheFileMap))
                 );
                 // Write map file
                 GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cacheFileMap), $result['sourceMap']);

--- a/Classes/Parser/ScssParser.php
+++ b/Classes/Parser/ScssParser.php
@@ -51,6 +51,7 @@ class ScssParser extends AbstractParser
         $cacheIdentifier = $this->getCacheIdentifier($file, $settings);
         $cacheFile = $this->getCacheFile($cacheIdentifier, $settings['cache']['tempDirectory']);
         $cacheFileMeta = $this->getCacheFileMeta($cacheFile);
+        $cacheFileMap = $this->getCacheFileMap($cacheFile);
         $compile = false;
 
         if (!$this->isCached($file, $settings)
@@ -60,7 +61,18 @@ class ScssParser extends AbstractParser
 
         if ($compile) {
             $result = $this->parseFile($file, $settings);
-            GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cacheFile), $result['css']);
+            if ($settings['options']['sourceMap']) {
+                // Write css file and append reference to source map file
+                GeneralUtility::writeFile(
+                    GeneralUtility::getFileAbsFileName($cacheFile),
+                    sprintf("%s /*# sourceMappingURL=%s */", $result['css'], basename($cacheFileMap))
+                );
+                // Write map file
+                GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cacheFileMap), $result['sourceMap']);
+            } else {
+                // Write css file
+                GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cacheFile), $result['css']);
+            }
             GeneralUtility::writeFile(GeneralUtility::getFileAbsFileName($cacheFileMeta), serialize($result['cache']));
             $this->clearPageCaches();
         }
@@ -79,10 +91,11 @@ class ScssParser extends AbstractParser
         $scss->setOutputStyle(OutputStyle::COMPRESSED);
         $scss->addVariables($settings['variables']);
         if ($settings['options']['sourceMap']) {
-            $scss->setSourceMap(Compiler::SOURCE_MAP_INLINE);
+            $scss->setSourceMap(Compiler::SOURCE_MAP_FILE);
             $scss->setSourceMapOptions([
                 'sourceMapRootpath' => $settings['cache']['tempDirectoryRelativeToRoot'],
-                'sourceMapBasepath' => '<PATH DOES NOT EXIST BUT SUPRESSES WARNINGS>'
+                'sourceMapBasepath' => Environment::getProjectPath(),
+                'outputSourceFiles' => true,
             ]);
         }
         $absoluteFilename = $settings['file']['absolute'];
@@ -145,8 +158,8 @@ class ScssParser extends AbstractParser
             }
         );
 
-        // Compile file
-        $compilationResult = $scss->compileString('@import "' . $absoluteFilename . '"');
+        // Compile file. Second parameter is needed for source mapping
+        $compilationResult = $scss->compileString('@import "' . $absoluteFilename . '"', $absoluteFilename);
         $css = $compilationResult->getCss();
 
         // Fix paths in url() statements to be relative to temp directory
@@ -157,6 +170,7 @@ class ScssParser extends AbstractParser
 
         return [
             'css' => $css,
+            'sourceMap' => $compilationResult->getSourceMap(),
             'cache' => [
                 'version' => Version::VERSION,
                 'date' => date('r'),

--- a/Tests/Functional/Parser/ScssParserTest.php
+++ b/Tests/Functional/Parser/ScssParserTest.php
@@ -126,4 +126,30 @@ class ScssParserTest extends FunctionalTestCase
             'url("../../../../typo3conf/ext/demo_package/Resources/Public/Images/PhotoSwipe/preloader.gif")'
         );
     }
+
+    /**
+     * @test
+     * @return void
+     * @dataProvider scssParserCanCompileTestDataProvider
+     */
+    public function sourceMapsAreIncluded($file): void
+    {
+        $compileService = GeneralUtility::makeInstance(CompileService::class);
+        $tsfeBackup = $GLOBALS['TSFE'];
+        $GLOBALS['TSFE'] = $this->mockTSFEWithSourceMappingEnabled();
+        $compiledFile = $compileService->getCompiledFile($file);
+        $mapFile = $compiledFile . '.map';
+        $GLOBALS['TSFE'] = $tsfeBackup;
+        self::assertFileExists(Environment::getPublicPath() . '/' . $mapFile);
+        self::assertFileContains(Environment::getPublicPath() . '/' . $compiledFile, '/*# sourceMappingURL=' . basename($mapFile));
+    }
+
+    protected function mockTSFEWithSourceMappingEnabled(): \stdClass
+    {
+        $tsfe = new \stdClass();
+        $tmpl = new \stdClass();
+        $tmpl->setup = ['plugin.' => ['tx_bootstrappackage.' => ['settings.' => ['sourceMapping' => true]]]];
+        $tsfe->tmpl = $tmpl;
+        return $tsfe;
+    }
 }

--- a/Tests/Functional/Parser/ScssParserTest.php
+++ b/Tests/Functional/Parser/ScssParserTest.php
@@ -63,7 +63,7 @@ class ScssParserTest extends FunctionalTestCase
     /**
      * @return array
      */
-    public function scssParserCanCompileTestDataProvider(): array
+    public static function scssParserCanCompileTestDataProvider(): array
     {
         return [
             'direct include' => [
@@ -148,7 +148,7 @@ class ScssParserTest extends FunctionalTestCase
     {
         $tsfe = new \stdClass();
         $tmpl = new \stdClass();
-        $tmpl->setup = ['plugin.' => ['tx_bootstrappackage.' => ['settings.' => ['sourceMapping' => true]]]];
+        $tmpl->setup = ['plugin.' => ['tx_bootstrappackage.' => ['settings.' => ['cssSourceMapping' => true]]]];
         $tsfe->tmpl = $tmpl;
         return $tsfe;
     }

--- a/Tests/Functional/Parser/ScssParserTest.php
+++ b/Tests/Functional/Parser/ScssParserTest.php
@@ -132,7 +132,7 @@ class ScssParserTest extends FunctionalTestCase
      * @return void
      * @dataProvider scssParserCanCompileTestDataProvider
      */
-    public function sourceMapsAreIncluded($file): void
+    public function sourceMapsAreIncluded(string $file): void
     {
         $compileService = GeneralUtility::makeInstance(CompileService::class);
         $tsfeBackup = $GLOBALS['TSFE'];


### PR DESCRIPTION
The source maps are no longer inlined in the compiled CSS file. There‘s a .css.map file for the compiled CSS file instead. Sources are now included into the map file. This means that sources can now be moved to non-public folders without losing the possibility to debug your code.

Related: #1263

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
