### PR TITLE
[TASK] Do not show search rules because they are confusing and not ac…

### DIFF
--- a/Configuration/TypoScript/Extension/IndexedSearch/setup.typoscript
+++ b/Configuration/TypoScript/Extension/IndexedSearch/setup.typoscript
@@ -2,6 +2,9 @@
 @import 'EXT:indexed_search/Configuration/TypoScript/setup.typoscript'
 
 plugin.tx_indexedsearch {
+    settings {
+        displayRules = 0
+    }
     view {
         templateRootPaths {
             20 = EXT:bootstrap_package/Resources/Private/Templates/IndexedSearch/


### PR DESCRIPTION
…cessible for any user

# Pull Request

## Related Issues

* Resolves #1302

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description
Problem:
In search form, the link "Rules" currently has no function. The information on search rules is not accessible to any users, as it sits in a data-content attribute on the link. The link is intransparent and confusing.

Solution:
see https://github.com/benjaminkott/bootstrap_package/issues/1302
1. Providing a button "Search Rules" in search forms and on click, showing a dialog (not a modal) with the information (currently the value of the data-content attribute)
OR
2. The information could also be displayed as an accordion item
OR
3. Less time consuming solution: The "Rules"-link could be removed, provided indexed search allows this

## Steps to Validate

1. Open the search form in the frontend
2. Check "Rules"-link below search form
