### PR TITLE
[TASK] only use aria-current for the last item in breadcrumb

### DIFF
--- a/Resources/Private/Partials/Page/Navigation/Breadcrumb.html
+++ b/Resources/Private/Partials/Page/Navigation/Breadcrumb.html
@@ -4,9 +4,9 @@
             <div class="container">
                 <p class="visually-hidden" id="breadcrumb">{f:translate(key: 'breadcrumb', extensionName: 'bootstrap_package')}</p>
                 <ol class="breadcrumb">
-                    <f:for each="{breadcrumb}" as="item">
+                    <f:for each="{breadcrumb}" as="item" iteration="iterator">
                         <f:variable name="isCurrent" value="0" />
-                        <f:if condition="{item.current} && {breadcrumbExtendedValue} == ''">
+                        <f:if condition="{item.current} && {breadcrumbExtendedValue} == '' && {iterator.isLast}">
                             <f:variable name="isCurrent" value="1" />
                         </f:if>
                         <li class="breadcrumb-item{f:if(condition: isCurrent, then: ' active')}"{f:if(condition: isCurrent, then: ' aria-current="page"')}>


### PR DESCRIPTION
Ref: #1326

# Pull Request

## Related Issues


## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.2

## Description

Only last item gets aria-current

## Steps to Validate

Got to page https://bitv-v12.live.typo3.cps.321.works/content-examples/text/rich-text ,and "Text" in breadcrump should not have aria-current
