### PR TITLE
[TASK] Add aria-labels for main and sub navigation

### DIFF
--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -25,6 +25,12 @@
                 <source>To top</source>
             </trans-unit>
 
+            <trans-unit id="main-navigation.label">
+                <source>main navigation</source>
+            </trans-unit>
+            <trans-unit id="sub-navigation.label">
+                <source>subnavigation</source>
+            </trans-unit>
             <trans-unit id="breadcrumb">
                 <source>You are here:</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -26,10 +26,10 @@
             </trans-unit>
 
             <trans-unit id="main-navigation.label">
-                <source>main navigation</source>
+                <source>Main navigation</source>
             </trans-unit>
             <trans-unit id="sub-navigation.label">
-                <source>subnavigation</source>
+                <source>Subnavigation</source>
             </trans-unit>
             <trans-unit id="breadcrumb">
                 <source>You are here:</source>

--- a/Resources/Private/Partials/Page/Navigation/Main.html
+++ b/Resources/Private/Partials/Page/Navigation/Main.html
@@ -8,7 +8,7 @@
         <f:render partial="Header/Logo" arguments="{_all}" />
         <f:if condition="{mainnavigation}">
             <f:render partial="Header/Toggle" arguments="{_all}" />
-            <nav id="mainnavigation" class="collapse navbar-collapse">
+            <nav aria-label="{f:translate(key: 'main-navigation.label', extensionName: 'bootstrap_package')}" id="mainnavigation" class="collapse navbar-collapse">
                 <f:render partial="DropIn/Navigation/MainBefore" arguments="{_all}" />
                 <f:render partial="Navigation/MainNavigation" arguments="{_all}" />
                 <f:render partial="DropIn/Navigation/MainAfter" arguments="{_all}" />

--- a/Resources/Private/Partials/Page/Navigation/Subnavigation.html
+++ b/Resources/Private/Partials/Page/Navigation/Subnavigation.html
@@ -1,7 +1,7 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:if condition="{subnavigation}">
     <!--TYPO3SEARCH_end-->
-    <nav class="frame frame-type-subnavigation frame-background-none frame-no-backgroundimage frame-space-before-none frame-space-after-none">
+    <nav aria-label="{f:translate(key: 'sub-navigation.label', extensionName: 'bootstrap_package')}" class="frame frame-type-subnavigation frame-background-none frame-no-backgroundimage frame-space-before-none frame-space-after-none">
         <div class="frame-container">
             <div class="frame-inner">
                 <f:render section="SubnavigationItem" arguments="{menu: subnavigation, theme: theme}" />


### PR DESCRIPTION
Related: #1291

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Related #1291

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Aria-Labels added for main and subnavigation as descirbed in ticket #1291

## Steps to Validate

1. pull
2. open page: https://bootstrap-package.ddev.site/content-examples/text/bullet-list
3. check if aria-label can be found on main and sub-navigatin (=in aside column)
