### PR TITLE
[BUGFIX] Handle allowed file extensions for TYPO3 v12

### DIFF
--- a/Classes/Utility/TcaUtility.php
+++ b/Classes/Utility/TcaUtility.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Utility;
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * TcaUtility
+ */
+class TcaUtility
+{
+    /**
+     * @param list<string> $allowed
+     * @param list<string> $disallowed
+     * @return array<string, mixed>
+     */
+    public static function getConfigForFileExtensions(array $allowed = [], array $disallowed = []): array
+    {
+        $allowedFileExtensions = implode(',', $allowed);
+        $disallowedFileExtensions = implode(',', $disallowed);
+
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            // See https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98479-NewTCATypeFile.html
+            return [
+                'allowed' => $allowedFileExtensions,
+                'disallowed' => $disallowedFileExtensions,
+            ];
+        }
+
+        // @todo Can be removed once support for TYPO3 v11.5 is dropped
+        return [
+            'filter' => [
+                0 => [
+                    'parameters' => [
+                        'allowedFileExtensions' => $allowedFileExtensions,
+                        'disallowedFileExtensions' => $disallowedFileExtensions,
+                    ],
+                ],
+            ],
+            'overrideChildTca' => [
+                'columns' => [
+                    'uid_local' => [
+                        'config' => [
+                            'appearance' => [
+                                'elementBrowserAllowed' => $allowedFileExtensions,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/Configuration/TCA/Overrides/201_content_element_audio.php
+++ b/Configuration/TCA/Overrides/201_content_element_audio.php
@@ -65,26 +65,7 @@ $GLOBALS['TCA']['tt_content']['types']['audio'] = array_replace_recursive(
         ',
         'columnsOverrides' => [
             'assets' => [
-                'config' => [
-                    'filter' => [
-                        0 => [
-                            'parameters' => [
-                                'allowedFileExtensions' => 'mp3'
-                            ]
-                        ]
-                    ],
-                    'overrideChildTca' => [
-                        'columns' => [
-                            'uid_local' => [
-                                'config' => [
-                                    'appearance' => [
-                                        'elementBrowserAllowed' => 'mp3'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                'config' => \BK2K\BootstrapPackage\Utility\TcaUtility::getConfigForFileExtensions(['mp3']),
             ]
         ]
     ]

--- a/Configuration/TCA/Overrides/207_content_element_csv.php
+++ b/Configuration/TCA/Overrides/207_content_element_csv.php
@@ -65,28 +65,7 @@ $GLOBALS['TCA']['tt_content']['types']['csv'] = array_replace_recursive(
         ',
         'columnsOverrides' => [
             'media' => [
-                'config' => [
-                    'filter' => [
-                        0 => [
-                            'parameters' => [
-                                'allowedFileExtensions' => 'csv'
-                            ]
-                        ]
-                    ],
-                    'minitems' => 0,
-                    'maxitems' => 1,
-                    'overrideChildTca' => [
-                        'columns' => [
-                            'uid_local' => [
-                                'config' => [
-                                    'appearance' => [
-                                        'elementBrowserAllowed' => 'csv'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                'config' => \BK2K\BootstrapPackage\Utility\TcaUtility::getConfigForFileExtensions(['csv']),
             ]
         ]
     ]

--- a/Configuration/TCA/Overrides/213_content_element_media.php
+++ b/Configuration/TCA/Overrides/213_content_element_media.php
@@ -69,26 +69,7 @@ $GLOBALS['TCA']['tt_content']['types']['media'] = array_replace_recursive(
         ',
         'columnsOverrides' => [
             'assets' => [
-                'config' => [
-                    'filter' => [
-                        0 => [
-                            'parameters' => [
-                                'allowedFileExtensions' => 'youtube, vimeo'
-                            ]
-                        ]
-                    ],
-                    'overrideChildTca' => [
-                        'columns' => [
-                            'uid_local' => [
-                                'config' => [
-                                    'appearance' => [
-                                        'elementBrowserAllowed' => 'youtube, vimeo'
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
+                'config' => \BK2K\BootstrapPackage\Utility\TcaUtility::getConfigForFileExtensions(['youtube', 'vimeo']),
             ]
         ]
     ]

--- a/Tests/Unit/Utility/TcaUtilityTest.php
+++ b/Tests/Unit/Utility/TcaUtilityTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Unit\Utility;
+
+use BK2K\BootstrapPackage\Utility\TcaUtility;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Testcase for class {@link TcaUtility}
+ */
+final class TcaUtilityTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function getConfigForFileExtensionsReturnsConfigArrayForTypo3V12(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 12) {
+            self::markTestSkipped('Test can only be executed in TYPO3 v12');
+        }
+
+        $expected = [
+            'allowed' => 'jpg,png',
+            'disallowed' => 'gif,youtube',
+        ];
+
+        self::assertSame(
+            $expected,
+            TcaUtility::getConfigForFileExtensions(['jpg', 'png'], ['gif', 'youtube'])
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function getConfigForFileExtensionsReturnsConfigArrayForTypo3V11(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 12) {
+            self::markTestSkipped('Test can only be executed in TYPO3 v11');
+        }
+
+        $expected = [
+            'filter' => [
+                0 => [
+                    'parameters' => [
+                        'allowedFileExtensions' => 'jpg,png',
+                        'disallowedFileExtensions' => 'gif,youtube',
+                    ],
+                ],
+            ],
+            'overrideChildTca' => [
+                'columns' => [
+                    'uid_local' => [
+                        'config' => [
+                            'appearance' => [
+                                'elementBrowserAllowed' => 'jpg,png',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        self::assertSame(
+            $expected,
+            TcaUtility::getConfigForFileExtensions(['jpg', 'png'], ['gif', 'youtube'])
+        );
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related Issues

–

## Prerequisites

* [x] Changes have been tested on TYPO3 v11.5 LTS
* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 7.4
* [x] Changes have been tested on PHP 8.0
* [x] Changes have been tested on PHP 8.1
* [x] Changes have been tested on PHP 8.2
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

With TYPO3 v12.0, a new TCA type [`file`](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-98479-NewTCATypeFile.html) was introduced. This type is used for the `tt_content.media` and `tt_content.assets` fields. Thus, all columns overrides for TYPO3 v12 must match the new TCA config.

This PR solves an issue with columns overrides of media columns concerning allowed file extensions. With the new TCA type, the expected TCA config looks different. In order to solve this issue and still support the previous behavior for TYPO3 v11.5, a new `TcaUtility` class is introduced. It returns a valid TCA config for allowed and/or disallowed file extensions, depending on the current TYPO3 version.

## Steps to Validate

1. Create a new content element of type "Audio" or "Media" in TYPO3 v11.5
2. Create a new content element of type "Audio" or "Media" in TYPO3 v12.4
3. Compare allowed file extensions across both installations