### PR TITLE
[TASK] Add legends to both fieldsets of contact form for better under…

### DIFF
--- a/Resources/Private/Forms/Contact.form.yaml
+++ b/Resources/Private/Forms/Contact.form.yaml
@@ -30,7 +30,7 @@ renderables:
           text: '* Mandatory fields'
         type: StaticText
         identifier: mandatory
-        label: 'Your personal data'
+        label: ''
       -
         type: GridRow
         identifier: gridrow
@@ -39,7 +39,7 @@ renderables:
           -
             type: Fieldset
             identifier: fieldset-left
-            label: ''
+            label: 'Your personal data'
             properties:
               gridColumnClassAutoConfiguration:
                 viewPorts:
@@ -86,7 +86,7 @@ renderables:
           -
             type: Fieldset
             identifier: fieldset-right
-            label: ''
+            label: 'Your message'
             properties:
               gridColumnClassAutoConfiguration:
                 viewPorts:


### PR DESCRIPTION
…standing

# Pull Request

## Related Issues

* Resolves #1304

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Problem:
In the contact form, fields are currently grouped into two fieldsets, neither of which is labelled. This is based on the form's layout and is confusing to screen reader users, because the grouping is not related to structure and/or content of the form.

Solution:
Adding legends to both of them helps the users to understand the form better.

## Steps to Validate

1. Open contact form in the frontend
2. Check form markup
