### PR TITLE
[TASK] Removed header tags from all headings for accessibility reason…

### DIFF
--- a/Resources/Private/Partials/ContentElements/Header/All.html
+++ b/Resources/Private/Partials/ContentElements/Header/All.html
@@ -1,27 +1,25 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:if condition="{data.header_layout} != 100">
     <f:if condition="{data.header} || {data.subheader} || {data.date}">
-        <header class="frame-header">
-            <f:render partial="Header/Header" arguments="{
-                header: data.header,
-                layout: data.header_layout,
-                class: settings.header.class,
-                displayClass: data.header_class,
-                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
-                link: data.header_link,
-                default: settings.header.defaultHeaderType}" />
-            <f:render partial="Header/SubHeader" arguments="{
-                subheader: data.subheader,
-                layout: data.header_layout,
-                class: settings.subheader.class,
-                displayClass: data.subheader_class,
-                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
-                default: settings.header.defaultHeaderType}" />
-            <f:render partial="Header/Date" arguments="{
-                date: data.date,
-                format: settings.header.date.format,
-                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}'}" />
-        </header>
+        <f:render partial="Header/Header" arguments="{
+            header: data.header,
+            layout: data.header_layout,
+            class: settings.header.class,
+            displayClass: data.header_class,
+            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
+            link: data.header_link,
+            default: settings.header.defaultHeaderType}" />
+        <f:render partial="Header/SubHeader" arguments="{
+            subheader: data.subheader,
+            layout: data.header_layout,
+            class: settings.subheader.class,
+            displayClass: data.subheader_class,
+            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
+            default: settings.header.defaultHeaderType}" />
+        <f:render partial="Header/Date" arguments="{
+            date: data.date,
+            format: settings.header.date.format,
+            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}'}" />
     </f:if>
 </f:if>
 </html>

--- a/Resources/Private/Partials/ContentElements/Header/All.html
+++ b/Resources/Private/Partials/ContentElements/Header/All.html
@@ -1,25 +1,27 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:if condition="{data.header_layout} != 100">
     <f:if condition="{data.header} || {data.subheader} || {data.date}">
-        <f:render partial="Header/Header" arguments="{
-            header: data.header,
-            layout: data.header_layout,
-            class: settings.header.class,
-            displayClass: data.header_class,
-            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
-            link: data.header_link,
-            default: settings.header.defaultHeaderType}" />
-        <f:render partial="Header/SubHeader" arguments="{
-            subheader: data.subheader,
-            layout: data.header_layout,
-            class: settings.subheader.class,
-            displayClass: data.subheader_class,
-            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
-            default: settings.header.defaultHeaderType}" />
-        <f:render partial="Header/Date" arguments="{
-            date: data.date,
-            format: settings.header.date.format,
-            positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}'}" />
+        <div class="frame-header">
+            <f:render partial="Header/Header" arguments="{
+                header: data.header,
+                layout: data.header_layout,
+                class: settings.header.class,
+                displayClass: data.header_class,
+                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
+                link: data.header_link,
+                default: settings.header.defaultHeaderType}" />
+            <f:render partial="Header/SubHeader" arguments="{
+                subheader: data.subheader,
+                layout: data.header_layout,
+                class: settings.subheader.class,
+                displayClass: data.subheader_class,
+                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}',
+                default: settings.header.defaultHeaderType}" />
+            <f:render partial="Header/Date" arguments="{
+                date: data.date,
+                format: settings.header.date.format,
+                positionClass: '{f:if(condition: data.header_position, then: \'text-{data.header_position}\')}'}" />
+        </div>
     </f:if>
 </f:if>
 </html>


### PR DESCRIPTION
…s (confusing to navigate without sight)

# Pull Request

## Related Issues

* Resolves #1292

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Problem:
Currently, each heading seems to come wrapped in a header. As they aren't nested in section, article or similar, all these headers relate to the page's main. This makes any page very confusing to navigate without sight.

Solution:
Remove header tags from content headings.

## Steps to Validate

1. Open any page
2. Check markup if headings do not have a `<header>`-tag wrapped around
