### PR TITLE
[TASK] Add new external media field to assign an iframe title (#1296)

### DIFF
--- a/Classes/Utility/ExternalMediaUtility.php
+++ b/Classes/Utility/ExternalMediaUtility.php
@@ -19,7 +19,7 @@ class ExternalMediaUtility
     /**
      * @var array Provider that can be handled, the provider is equal the hostname and needs a process function
      */
-    protected $mediaProvider = [
+    protected array $mediaProvider = [
         'youtube',
         'youtu',
         'vimeo'
@@ -28,13 +28,13 @@ class ExternalMediaUtility
     /**
      * Get the embed code for the given url if possible
      * and add a css class on the iframe
-     *
-     * @param string $url
-     * @param string $class
-     * @return string|null
      */
-    public function getEmbedCode(string $url, string $class): ?string
+    public function getEmbedCode(?string $url, ?string $class, ?string $title = null): ?string
     {
+        if ($url === null || $url === '') {
+            return null;
+        }
+
         // Prepare url
         $url = $this->setProtocolToHttps($url);
         // Get method
@@ -42,11 +42,17 @@ class ExternalMediaUtility
         if ($method !== null) {
             $embedUrl = $this->{$method}($url);
             if ($embedUrl !== null) {
-                return '<iframe ' . GeneralUtility::implodeAttributes([
-                        'class' => $class,
-                        'src' => $embedUrl,
-                        'frameborder' => '0'
-                    ], true) . ' allowfullscreen></iframe>';
+                $attributes = [
+                    'src' => $embedUrl,
+                    'frameborder' => '0'
+                ];
+                if ($title !== null && trim($title) !== '') {
+                    $attributes['title'] = trim($title);
+                }
+                if ($class !== null && trim($class) !== '') {
+                    $attributes['class'] = trim($class);
+                }
+                return '<iframe ' . GeneralUtility::implodeAttributes($attributes, true) . ' allowfullscreen></iframe>';
             }
         }
         return null;
@@ -54,9 +60,6 @@ class ExternalMediaUtility
 
     /**
      * Resolves if possible a method name to process the url
-     *
-     * @param string $url
-     * @return string|null
      */
     protected function getMethod(string $url): ?string
     {
@@ -75,9 +78,6 @@ class ExternalMediaUtility
 
     /**
      * Processes YouTube url
-     *
-     * @param string $url
-     * @return string|null
      */
     protected function processYoutube(string $url): ?string
     {
@@ -99,9 +99,6 @@ class ExternalMediaUtility
 
     /**
      * Process YouTube short url
-     *
-     * @param string $url
-     * @return string|null
      */
     protected function processYoutu(string $url): ?string
     {
@@ -110,9 +107,6 @@ class ExternalMediaUtility
 
     /**
      * Processes Vimeo url
-     *
-     * @param string $url
-     * @return string
      */
     protected function processVimeo(string $url): ?string
     {
@@ -125,9 +119,6 @@ class ExternalMediaUtility
 
     /**
      * Change every protocol to https and add it if missing
-     *
-     * @param  string $url URL
-     * @return string
      */
     protected function setProtocolToHttps(string $url): string
     {

--- a/Classes/ViewHelpers/ExternalMediaViewHelper.php
+++ b/Classes/ViewHelpers/ExternalMediaViewHelper.php
@@ -36,6 +36,7 @@ class ExternalMediaViewHelper extends AbstractViewHelper
     public function initializeArguments()
     {
         parent::initializeArguments();
+        $this->registerArgument('title', 'string', 'External media iframe title');
         $this->registerArgument('url', 'string', 'External media url');
         $this->registerArgument('class', 'string', 'CSS class rendered on the generated iframe code');
     }
@@ -57,7 +58,7 @@ class ExternalMediaViewHelper extends AbstractViewHelper
     ) {
         $variableProvider = $renderingContext->getVariableProvider();
         $externalMediaUtility = GeneralUtility::makeInstance(ExternalMediaUtility::class);
-        $externalMedia = $externalMediaUtility->getEmbedCode($arguments['url'], $arguments['class']);
+        $externalMedia = $externalMediaUtility->getEmbedCode($arguments['url'], $arguments['class'], $arguments['title']);
         $variableProvider->add('externalMedia', $externalMedia);
         $content = $renderChildrenClosure();
         $variableProvider->remove('externalMedia');

--- a/Configuration/TCA/Overrides/208_content_element_externalmedia.php
+++ b/Configuration/TCA/Overrides/208_content_element_externalmedia.php
@@ -68,6 +68,14 @@ $GLOBALS['TCA']['tt_content']['types']['external_media'] = array_replace_recursi
 $GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
     $GLOBALS['TCA']['tt_content']['columns'],
     [
+        'external_media_title' => [
+            'label' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.external_media_title',
+            'config' => [
+                'type' => 'input',
+                'size' => 50,
+                'max' => 255,
+            ]
+        ],
         'external_media_source' => [
             'label' => 'LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:field.external_media_source',
             'config' => [
@@ -94,6 +102,7 @@ $GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
 // Register palettes
 $GLOBALS['TCA']['tt_content']['palettes']['external_media'] = [
     'showitem' => '
+        external_media_title, --linebreak--,
         external_media_source, --linebreak--,
         external_media_ratio
     '

--- a/Resources/Private/Language/Backend.xlf
+++ b/Resources/Private/Language/Backend.xlf
@@ -771,6 +771,9 @@
             <trans-unit id="external_media">
                 <source>External Media</source>
             </trans-unit>
+            <trans-unit id="field.external_media_title">
+                <source>External Media Title</source>
+            </trans-unit>
             <trans-unit id="field.external_media_source">
                 <source>External Media Source</source>
             </trans-unit>

--- a/Resources/Private/Templates/ContentElements/ExternalMedia.html
+++ b/Resources/Private/Templates/ContentElements/ExternalMedia.html
@@ -2,7 +2,7 @@
 <f:layout name="Default" />
 <f:section name="Main">
 
-    <bk2k:externalMedia url="{data.external_media_source}" class="embed-responsive-item">
+    <bk2k:externalMedia title="{data.external_media_title}" url="{data.external_media_source}" class="embed-responsive-item">
         <f:if condition="{externalMedia}">
             <f:then>
                 <div class="embed-responsive embed-responsive-{data.external_media_ratio}">

--- a/Resources/Private/Templates/Preview/ExternalMedia.html
+++ b/Resources/Private/Templates/Preview/ExternalMedia.html
@@ -1,6 +1,6 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
 <br>
-<bk2k:externalMedia url="{external_media_source}" class="embed-responsive-item">
+<bk2k:externalMedia iframeTitle="{external_media_title}" url="{external_media_source}" class="embed-responsive-item">
     <f:if condition="{externalMedia}">
         <f:then>
             <div style="max-width: 400px;">

--- a/Tests/Unit/Utility/ExternalMediaUtilityTest.php
+++ b/Tests/Unit/Utility/ExternalMediaUtilityTest.php
@@ -20,13 +20,14 @@ class ExternalMediaUtilityTest extends UnitTestCase
     /**
      * @param string $url
      * @param string $class
+     * @param string $title
      * @param string $expectedResult
      * @dataProvider getEmbedCodeDataProvider
      * @test
      */
-    public function getEmbedCode(string $url, string $class, $expectedResult): void
+    public function getEmbedCode(?string $url, ?string $class, ?string $title, $expectedResult): void
     {
-        self::assertSame($expectedResult, (new ExternalMediaUtility())->getEmbedCode($url, $class));
+        self::assertSame($expectedResult, (new ExternalMediaUtility())->getEmbedCode($url, $class, $title));
     }
 
     /**
@@ -35,17 +36,76 @@ class ExternalMediaUtilityTest extends UnitTestCase
     public static function getEmbedCodeDataProvider(): array
     {
         return [
-            'empty' => ['', '', null],
-            'www.youtube.com' => ['https://www.youtube.com/watch?v=zpOVYePk6mM', '', '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'youtube.com' => ['https://youtube.com/watch?v=zpOVYePk6mM', '', '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'www.youtu.be' => ['https://www.youtu.be/zpOVYePk6mM', '', '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'youtu.de' => ['https://youtu.be/zpOVYePk6mM', '', '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'vimeo' => ['https://vimeo.com/143018597', '', '<iframe src="https://player.vimeo.com/video/143018597" frameborder="0" allowfullscreen></iframe>'],
-            'www.youtube.com with class' => ['https://www.youtube.com/watch?v=zpOVYePk6mM', 'test', '<iframe class="test" src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'youtube.com with class' => ['https://youtube.com/watch?v=zpOVYePk6mM', 'test', '<iframe class="test" src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'www.youtu.be with class' => ['https://www.youtu.be/zpOVYePk6mM', 'test', '<iframe class="test" src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'youtu.de with class' => ['https://youtu.be/zpOVYePk6mM', 'test', '<iframe class="test" src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'],
-            'vimeo with class' => ['https://vimeo.com/143018597', 'test', '<iframe class="test" src="https://player.vimeo.com/video/143018597" frameborder="0" allowfullscreen></iframe>'],
+            // empty
+            'empty null' => [
+                null,
+                null,
+                null,
+                null
+            ],
+            'empty string' => [
+                '',
+                '',
+                '',
+                null
+            ],
+            // url variants
+            'www.youtube.com' => [
+                'https://www.youtube.com/watch?v=zpOVYePk6mM',
+                null,
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
+            'youtube.com' => [
+                'https://youtube.com/watch?v=zpOVYePk6mM',
+                null,
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
+            'www.youtu.be' => [
+                'https://www.youtu.be/zpOVYePk6mM',
+                null,
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
+            'youtu.de' => [
+                'https://youtu.be/zpOVYePk6mM',
+                null,
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
+            'vimeo' => [
+                'https://vimeo.com/143018597',
+                null,
+                null,
+                '<iframe src="https://player.vimeo.com/video/143018597" frameborder="0" allowfullscreen></iframe>'
+            ],
+            // class
+            'with class' => [
+                'https://www.youtube.com/watch?v=zpOVYePk6mM',
+                'demo',
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" class="demo" allowfullscreen></iframe>'
+            ],
+            'with class empty' => [
+                'https://www.youtube.com/watch?v=zpOVYePk6mM',
+                ' ',
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
+            // title
+            'with title' => [
+                'https://www.youtube.com/watch?v=zpOVYePk6mM',
+                null,
+                'demo',
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" title="demo" allowfullscreen></iframe>'
+            ],
+            'with title empty' => [
+                'https://www.youtube.com/watch?v=zpOVYePk6mM',
+                null,
+                ' ',
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>'
+            ],
         ];
     }
 }

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -31,6 +31,7 @@ CREATE TABLE tt_content (
     icon_type varchar(60) DEFAULT 'default' NOT NULL,
     icon_color varchar(255) DEFAULT '' NOT NULL,
     icon_background varchar(255) DEFAULT '' NOT NULL,
+    external_media_title varchar(255) DEFAULT '' NOT NULL,
     external_media_source varchar(1024) DEFAULT '' NOT NULL,
     external_media_ratio varchar(10) DEFAULT '' NOT NULL,
     tx_bootstrappackage_card_group_item int(11) unsigned DEFAULT '0',


### PR DESCRIPTION
# Pull Request

## Related Issues

* Resolves #1296

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on PHP 8.1

## Description

Problem:
All frames should have a title attribute containing information about the frame's content. Currently, iframes with YouTube videos are only labelled with the video's title.

Solution:
Add new field to external media content element to assign an iframe title.

## Steps to Validate

1. Create a "External Media" content element on any page and fill out "External Media iframe title"
2. Open page in the frontend and check iframe markup
3. Title attribute should be set
