### PR TITLE
[TASK] Move Registering of Icons to ServiceContainer 

### DIFF
--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,4 +1,12 @@
 <?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
 return [
     'systeminformation-bootstrappackage' => [
         'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -1,0 +1,119 @@
+<?php
+return [
+    'systeminformation-bootstrappackage' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/SystemInformation/bootstrappackage.svg'
+    ],
+    'content-bootstrappackage-accordion' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/accordion.svg'
+    ],
+    'content-bootstrappackage-accordion-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/accordion-item.svg'
+    ],
+    'content-bootstrappackage-card-group' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/card-group.svg'
+    ],
+    'content-bootstrappackage-card-group-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/card-group-item.svg'
+    ],
+    'content-bootstrappackage-carousel' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel.svg'
+    ],
+    'content-bootstrappackage-carousel-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item.svg'
+    ],
+    'content-bootstrappackage-carousel-item-backgroundimage' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-backgroundimage.svg'
+    ],
+    'content-bootstrappackage-carousel-item-calltoaction' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-calltoaction.svg'
+    ],
+    'content-bootstrappackage-carousel-item-header' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-header.svg'
+    ],
+    'content-bootstrappackage-carousel-item-html' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-html.svg'
+    ],
+    'content-bootstrappackage-carousel-item-image' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-image.svg'
+    ],
+    'content-bootstrappackage-carousel-item-text' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-text.svg'
+    ],
+    'content-bootstrappackage-carousel-item-textandimage' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/carousel-item-textandimage.svg'
+    ],
+    'content-bootstrappackage-beside-text-img-centered-left' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/beside-text-img-centered-left.svg'
+    ],
+    'content-bootstrappackage-beside-text-img-centered-right' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/beside-text-img-centered-right.svg'
+    ],
+    'content-bootstrappackage-csv' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/csv.svg'
+    ],
+    'content-bootstrappackage-externalmedia' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/externalmedia.svg'
+    ],
+    'content-bootstrappackage-gallery' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/gallery.svg'
+    ],
+    'content-bootstrappackage-icon-group' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/icon-group.svg'
+    ],
+    'content-bootstrappackage-icon-group-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/icon-group-item.svg'
+    ],
+    'content-bootstrappackage-listgroup' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/listgroup.svg'
+    ],
+    'content-bootstrappackage-menu-card' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/menu-card.svg'
+    ],
+    'content-bootstrappackage-social-links' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/social-links.svg'
+    ],
+    'content-bootstrappackage-tab' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/tab.svg'
+    ],
+    'content-bootstrappackage-tab-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/tab-item.svg'
+    ],
+    'content-bootstrappackage-texticon' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/texticon.svg'
+    ],
+    'content-bootstrappackage-timeline' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/timeline.svg'
+    ],
+    'content-bootstrappackage-timeline-item' => [
+        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/timeline-item.svg'
+    ],
+];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -142,5 +142,3 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\BK2K\Bootstr
 
 // Register "bk2k" as global fluid namespace
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['bk2k'][] = 'BK2K\\BootstrapPackage\\ViewHelpers';
-
-

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -143,47 +143,4 @@ $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update'][\BK2K\Bootstr
 // Register "bk2k" as global fluid namespace
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['bk2k'][] = 'BK2K\\BootstrapPackage\\ViewHelpers';
 
-// Register Icons
-$iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-$iconRegistry->registerIcon(
-    'systeminformation-bootstrappackage',
-    \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-    ['source' => 'EXT:bootstrap_package/Resources/Public/Icons/SystemInformation/bootstrappackage.svg']
-);
-$icons = [
-    'accordion',
-    'accordion-item',
-    'card-group',
-    'card-group-item',
-    'carousel',
-    'carousel-item',
-    'carousel-item-backgroundimage',
-    'carousel-item-calltoaction',
-    'carousel-item-header',
-    'carousel-item-html',
-    'carousel-item-image',
-    'carousel-item-text',
-    'carousel-item-textandimage',
-    'beside-text-img-centered-left',
-    'beside-text-img-centered-right',
-    'csv',
-    'externalmedia',
-    'gallery',
-    'icon-group',
-    'icon-group-item',
-    'listgroup',
-    'menu-card',
-    'social-links',
-    'tab',
-    'tab-item',
-    'texticon',
-    'timeline',
-    'timeline-item'
-];
-foreach ($icons as $icon) {
-    $iconRegistry->registerIcon(
-        'content-bootstrappackage-' . $icon,
-        \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
-        ['source' => 'EXT:bootstrap_package/Resources/Public/Icons/ContentElements/' . $icon . '.svg']
-    );
-}
+


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ x] Changes have been tested on TYPO3 v11.5 LTS
* [ x] Changes have been tested on TYPO3 v12.4 LTS
* [x ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [x ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ x] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Use Configuration/Icons.php see
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Feature-94692-RegisteringIconsViaServiceContainer.html

## Steps to Validate

