### PR TITLE
[TASK] Remove obsolete intrinsicsize attribute

### DIFF
--- a/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
+++ b/Resources/Private/Partials/ContentElements/Media/Rendering/Image.html
@@ -50,6 +50,6 @@
     </f:if>
     <f:variable name="finalWidth" value="{bk2k:data.imageInfo(src: src, property: 'width')}" />
     <f:variable name="finalHeight" value="{bk2k:data.imageInfo(src: src, property: 'height')}" />
-    <img loading="lazy" src="{src}" width="{finalWidth}" height="{finalHeight}" intrinsicsize="{finalWidth}x{finalHeight}" title="{file.properties.title}" alt="{file.properties.alternative}">
+    <img loading="lazy" src="{src}" width="{finalWidth}" height="{finalHeight}" title="{file.properties.title}" alt="{file.properties.alternative}">
 </picture>
 </html>


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

intrinsicsize was a suggested attribute for all HTML media elements and was previously implemented by Google Chrome. However, it wasn't implemented by any other browser because height/width are now used to calculate the initial aspect ratio.

Explanation: https://github.com/WICG/intrinsicsize-attribute/issues/16
Chrome status: https://chromestatus.com/feature/4704436815396864