### PR TITLE
Add property hight to allow cropping

### DIFF
--- a/Classes/Utility/ImageVariantsUtility.php
+++ b/Classes/Utility/ImageVariantsUtility.php
@@ -21,6 +21,7 @@ class ImageVariantsUtility
     protected static $allowedVariantProperties = [
         'breakpoint',
         'width',
+        'height',
         'aspectRatio',
         'sizes',
     ];


### PR DESCRIPTION
With only width the images will have the same ratio width/height. With the extra parameter height it is possible to adjust without the need to crop them all in the editor.
