### PR TITLE
[TASK] Cleanup esm migration

### DIFF
--- a/Resources/Public/JavaScript/ESM/backend/form-editor/grid-column-view-model.js
+++ b/Resources/Public/JavaScript/ESM/backend/form-editor/grid-column-view-model.js
@@ -1,48 +1,14 @@
-/**
- * Module: @bk2k/bootstrap-package/backend/form-editor/grid-column-view-model.js
- */
-
-import $ from 'jquery';
-import * as StageComponent from '@typo3/form/backend/form-editor/stage-component.js';
-
-/**
- * @private
- *
- * @return object
- */
-function getPublisherSubscriber(formEditorApp) {
-    return formEditorApp.getPublisherSubscriber();
-}
-
-/**
- * @private
- *
- * @return void
- */
-function subscribeEvents(formEditorApp) {
-    /**
-     * @private
-     *
-     * @param string
-     * @param array
-     *              args[0] = formElement
-     *              args[1] = template
-     * @return void
-     * @subscribe view/stage/abstract/render/template/perform
-     */
-    getPublisherSubscriber(formEditorApp).subscribe('view/stage/abstract/render/template/perform', function (topic, args) {
-        if (args[0].get('type') === 'GridColumn') {
-            StageComponent.renderCheckboxTemplate(args[0], args[1]);
+function subscribeEvents(formEditor) {
+    formEditor.getPublisherSubscriber().subscribe('view/stage/abstract/render/template/perform', (
+        topic,
+        [formElement, template]
+    ) => {
+        if (formElement.get('type') === 'GridColumn') {
+            formEditor.getViewModel().getStage().renderSimpleTemplateWithValidators(formElement, template);
         }
     });
-}
+};
 
-/**
- * @public
- *
- * @param object formEditorApp
- * @return void
- */
 export function bootstrap(formEditorApp) {
     subscribeEvents(formEditorApp);
-}
+};

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "typo3/cms-belog": "^12.4 || 13.*.*@dev",
         "typo3/cms-felogin": "^12.4 || 13.*.*@dev",
         "typo3/cms-filelist": "^12.4 || 13.*.*@dev",
-        "typo3/cms-form": "^12.4 || 13.*.*@dev",
+        "typo3/cms-form": "^12.4.5 || 13.*.*@dev",
         "typo3/cms-indexed-search": "^12.4 || 13.*.*@dev",
         "typo3/cms-info": "^12.4 || 13.*.*@dev",
         "typo3/cms-lowlevel": "^12.4 || 13.*.*@dev",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,9 +13,9 @@ $EM_CONF[$_EXTKEY] = [
     'category' => 'templates',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-12.4.99',
-            'rte_ckeditor' => '11.5.0-12.4.99',
-            'seo' => '11.5.0-12.4.99'
+            'typo3' => '12.4.5-12.4.99',
+            'rte_ckeditor' => '12.4.5-12.4.99',
+            'seo' => '12.4.5-12.4.99'
         ],
         'conflicts' => [
             'css_styled_content' => '*',


### PR DESCRIPTION
 * Require at least TYPO3 v12.4.5 as a bug was preent until v12.4.4 https://review.typo3.org/c/Packages/TYPO3.CMS/+/80174
 * Remove jquery requirement
 * Use instanciated stage module (like the core does as well)
 * Use array unfolding to make generic args array elements readable without requiring doc comments
 * Avoid unneeded doc comments