### PR TITLE
[TASK] Remove deprecated TCEforms flexform XML element

### DIFF
--- a/Configuration/FlexForms/Accordion.xml
+++ b/Configuration/FlexForms/Accordion.xml
@@ -6,28 +6,24 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <default_element>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:accordion.default_element
-                            </label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <foreign_table>tx_bootstrappackage_accordion_item</foreign_table>
-                                <foreign_table_where>AND tx_bootstrappackage_accordion_item.tt_content = ###THIS_UID###</foreign_table_where>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">None</numIndex>
-                                        <numIndex index="1">0</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:accordion.default_element
+                        </label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <foreign_table>tx_bootstrappackage_accordion_item</foreign_table>
+                            <foreign_table_where>AND tx_bootstrappackage_accordion_item.tt_content = ###THIS_UID###</foreign_table_where>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">None</numIndex>
+                                    <numIndex index="1">0</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </default_element>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/BackgroundImage.xml
+++ b/Configuration/FlexForms/BackgroundImage.xml
@@ -6,86 +6,76 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <behaviour>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default></default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour.cover</numIndex>
-                                        <numIndex index="1">cover</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour.pattern</numIndex>
-                                        <numIndex index="1">pattern</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default></default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour.cover</numIndex>
+                                    <numIndex index="1">cover</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.behaviour.pattern</numIndex>
+                                    <numIndex index="1">pattern</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </behaviour>
                     <parallax>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.parallax</label>
-                            <config>
-                                <type>check</type>
-                                <default>0</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.parallax.description</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.parallax</label>
+                        <config>
+                            <type>check</type>
+                            <default>0</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.parallax.description</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </parallax>
                     <fade>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.fade</label>
-                            <config>
-                                <type>check</type>
-                                <default>0</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.fade.description</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.fade</label>
+                        <config>
+                            <type>check</type>
+                            <default>0</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.fade.description</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </fade>
                     <filter>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default></default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.none</numIndex>
-                                        <numIndex index="1"></numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.blur</numIndex>
-                                        <numIndex index="1">blur</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.grayscale</numIndex>
-                                        <numIndex index="1">grayscale</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.sepia</numIndex>
-                                        <numIndex index="1">sepia</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default></default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.none</numIndex>
+                                    <numIndex index="1"></numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.blur</numIndex>
+                                    <numIndex index="1">blur</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.grayscale</numIndex>
+                                    <numIndex index="1">grayscale</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:option.background_image.filter.sepia</numIndex>
+                                    <numIndex index="1">sepia</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </filter>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/CardGroup.xml
+++ b/Configuration/FlexForms/CardGroup.xml
@@ -6,62 +6,56 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <align>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>left</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.left</numIndex>
-                                        <numIndex index="1">left</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.center</numIndex>
-                                        <numIndex index="1">center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.right</numIndex>
-                                        <numIndex index="1">right</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>left</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.left</numIndex>
+                                    <numIndex index="1">left</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.center</numIndex>
+                                    <numIndex index="1">center</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.align.right</numIndex>
+                                    <numIndex index="1">right</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </align>
                     <columns>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.columns</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>2</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">1</numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">2</numIndex>
-                                        <numIndex index="1">2</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">4</numIndex>
-                                        <numIndex index="1">4</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.card_group.columns</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>2</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">1</numIndex>
+                                    <numIndex index="1">1</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">2</numIndex>
+                                    <numIndex index="1">2</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">3</numIndex>
+                                    <numIndex index="1">3</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">4</numIndex>
+                                    <numIndex index="1">4</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </columns>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/Carousel.xml
+++ b/Configuration/FlexForms/Carousel.xml
@@ -6,85 +6,73 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <autoplay>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.autoplay</label>
-                            <config>
-                                <type>check</type>
-                                <default>0</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.autoplay.description</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.autoplay</label>
+                        <config>
+                            <type>check</type>
+                            <default>0</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.autoplay.description</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </autoplay>
                     <interval>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.interval
-                            </label>
-                            <config>
-                                <type>input</type>
-                                <size>8</size>
-                                <default>5000</default>
-                                <eval>required,int</eval>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.interval
+                        </label>
+                        <config>
+                            <type>input</type>
+                            <size>8</size>
+                            <default>5000</default>
+                            <eval>required,int</eval>
+                        </config>
                     </interval>
                     <transition>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition
-                            </label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>fade</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition.fade</numIndex>
-                                        <numIndex index="1">fade</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition.slide</numIndex>
-                                        <numIndex index="1">slide</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition
+                        </label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>fade</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition.fade</numIndex>
+                                    <numIndex index="1">fade</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.transition.slide</numIndex>
+                                    <numIndex index="1">slide</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </transition>
                     <wrap>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.wrap</label>
-                            <config>
-                                <type>check</type>
-                                <default>1</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.wrap.description</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.wrap</label>
+                        <config>
+                            <type>check</type>
+                            <default>1</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.wrap.description</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </wrap>
                     <show_nav_title>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.show_nav_title</label>
-                            <config>
-                                <type>check</type>
-                                <default>0</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.show_nav_title.description</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.show_nav_title</label>
+                        <config>
+                            <type>check</type>
+                            <default>0</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:carousel.show_nav_title.description</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </show_nav_title>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/IconGroup.xml
+++ b/Configuration/FlexForms/IconGroup.xml
@@ -6,102 +6,94 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <align>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>center</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.left</numIndex>
-                                        <numIndex index="1">left</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.center</numIndex>
-                                        <numIndex index="1">center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.right</numIndex>
-                                        <numIndex index="1">right</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>center</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.left</numIndex>
+                                    <numIndex index="1">left</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.center</numIndex>
+                                    <numIndex index="1">center</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.align.right</numIndex>
+                                    <numIndex index="1">right</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </align>
                     <columns>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.columns</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>auto</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.columns.auto</numIndex>
-                                        <numIndex index="1">auto</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">1</numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">2</numIndex>
-                                        <numIndex index="1">2</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">4</numIndex>
-                                        <numIndex index="1">4</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.columns</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>auto</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.columns.auto</numIndex>
+                                    <numIndex index="1">auto</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">1</numIndex>
+                                    <numIndex index="1">1</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">2</numIndex>
+                                    <numIndex index="1">2</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">3</numIndex>
+                                    <numIndex index="1">3</numIndex>
+                                </numIndex>
+                                <numIndex index="4" type="array">
+                                    <numIndex index="0">4</numIndex>
+                                    <numIndex index="1">4</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </columns>
                     <icon_position>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>left-center</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.left-top</numIndex>
-                                        <numIndex index="1">left-top</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.left-center</numIndex>
-                                        <numIndex index="1">left-center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.right-top</numIndex>
-                                        <numIndex index="1">right-top</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.right-center</numIndex>
-                                        <numIndex index="1">right-center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="4" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.above</numIndex>
-                                        <numIndex index="1">above</numIndex>
-                                    </numIndex>
-                                    <numIndex index="5" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.below</numIndex>
-                                        <numIndex index="1">below</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>left-center</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.left-top</numIndex>
+                                    <numIndex index="1">left-top</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.left-center</numIndex>
+                                    <numIndex index="1">left-center</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.right-top</numIndex>
+                                    <numIndex index="1">right-top</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.right-center</numIndex>
+                                    <numIndex index="1">right-center</numIndex>
+                                </numIndex>
+                                <numIndex index="4" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.above</numIndex>
+                                    <numIndex index="1">above</numIndex>
+                                </numIndex>
+                                <numIndex index="5" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:content_element.icon_group.icon_position.below</numIndex>
+                                    <numIndex index="1">below</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </icon_position>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/MenuCard.xml
+++ b/Configuration/FlexForms/MenuCard.xml
@@ -6,62 +6,56 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <align>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>left</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.left</numIndex>
-                                        <numIndex index="1">left</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.center</numIndex>
-                                        <numIndex index="1">center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.right</numIndex>
-                                        <numIndex index="1">right</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>left</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.left</numIndex>
+                                    <numIndex index="1">left</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.center</numIndex>
+                                    <numIndex index="1">center</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.align.right</numIndex>
+                                    <numIndex index="1">right</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </align>
                     <columns>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.columns</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>2</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">1</numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">2</numIndex>
-                                        <numIndex index="1">2</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">4</numIndex>
-                                        <numIndex index="1">4</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.card.columns</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>2</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">1</numIndex>
+                                    <numIndex index="1">1</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">2</numIndex>
+                                    <numIndex index="1">2</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">3</numIndex>
+                                    <numIndex index="1">3</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">4</numIndex>
+                                    <numIndex index="1">4</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </columns>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/MenuThumbnail.xml
+++ b/Configuration/FlexForms/MenuThumbnail.xml
@@ -6,62 +6,56 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <align>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>left</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.left</numIndex>
-                                        <numIndex index="1">left</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.center</numIndex>
-                                        <numIndex index="1">center</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.right</numIndex>
-                                        <numIndex index="1">right</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>left</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.left</numIndex>
+                                    <numIndex index="1">left</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.center</numIndex>
+                                    <numIndex index="1">center</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.align.right</numIndex>
+                                    <numIndex index="1">right</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </align>
                     <columns>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.columns</label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <default>2</default>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">1</numIndex>
-                                        <numIndex index="1">1</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">2</numIndex>
-                                        <numIndex index="1">2</numIndex>
-                                    </numIndex>
-                                    <numIndex index="2" type="array">
-                                        <numIndex index="0">3</numIndex>
-                                        <numIndex index="1">3</numIndex>
-                                    </numIndex>
-                                    <numIndex index="3" type="array">
-                                        <numIndex index="0">4</numIndex>
-                                        <numIndex index="1">4</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:menu.thumbnail.columns</label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <default>2</default>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">1</numIndex>
+                                    <numIndex index="1">1</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">2</numIndex>
+                                    <numIndex index="1">2</numIndex>
+                                </numIndex>
+                                <numIndex index="2" type="array">
+                                    <numIndex index="0">3</numIndex>
+                                    <numIndex index="1">3</numIndex>
+                                </numIndex>
+                                <numIndex index="3" type="array">
+                                    <numIndex index="0">4</numIndex>
+                                    <numIndex index="1">4</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </columns>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/Tab.xml
+++ b/Configuration/FlexForms/Tab.xml
@@ -6,28 +6,24 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <default_tab>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:tab.default_tab
-                            </label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <foreign_table>tx_bootstrappackage_tab_item</foreign_table>
-                                <foreign_table_where>AND tx_bootstrappackage_tab_item.tt_content = ###THIS_UID###</foreign_table_where>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0"></numIndex>
-                                        <numIndex index="1">0</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:tab.default_tab
+                        </label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <foreign_table>tx_bootstrappackage_tab_item</foreign_table>
+                            <foreign_table_where>AND tx_bootstrappackage_tab_item.tt_content = ###THIS_UID###</foreign_table_where>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0"></numIndex>
+                                    <numIndex index="1">0</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </default_tab>
                 </el>
             </ROOT>

--- a/Configuration/FlexForms/Timeline.xml
+++ b/Configuration/FlexForms/Timeline.xml
@@ -6,30 +6,26 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:settings</sheetTitle>
                 <type>array</type>
                 <el>
                     <sorting>
-                        <TCEforms>
-                            <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting
-                            </label>
-                            <config>
-                                <type>select</type>
-                                <renderType>selectSingle</renderType>
-                                <items type="array">
-                                    <numIndex index="0" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting.desc</numIndex>
-                                        <numIndex index="1">date desc</numIndex>
-                                    </numIndex>
-                                    <numIndex index="1" type="array">
-                                        <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting.asc</numIndex>
-                                        <numIndex index="1">date asc</numIndex>
-                                    </numIndex>
-                                </items>
-                            </config>
-                        </TCEforms>
+                        <label>LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting
+                        </label>
+                        <config>
+                            <type>select</type>
+                            <renderType>selectSingle</renderType>
+                            <items type="array">
+                                <numIndex index="0" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting.desc</numIndex>
+                                    <numIndex index="1">date desc</numIndex>
+                                </numIndex>
+                                <numIndex index="1" type="array">
+                                    <numIndex index="0">LLL:EXT:bootstrap_package/Resources/Private/Language/Backend.xlf:timeline.sorting.asc</numIndex>
+                                    <numIndex index="1">date asc</numIndex>
+                                </numIndex>
+                            </items>
+                        </config>
                     </sorting>
                 </el>
             </ROOT>


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes # [bug]

## Prerequisites

* [X] Changes have been tested on TYPO3 v12.4 LTS
* [X] Changes have been tested on PHP 8.0
* [X] Changes have been tested on PHP 8.1
* [X] Changes have been tested on PHP 8.2
* [X] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Using TCEforms within flexform definitions has been deprecated in v12 and removed in v13:

https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Deprecation-97126-TCEformsRemovedInFlexForm.html

This patch is compatible to v12 and v13 by removing this element.

(Otherwise, in v13, all flexform options would not be editable)

## Steps to Validate

1. In v13, create an carousel item. 
2. Check the flexform options in Tab "Carousel Options".
3. See that all option keys are listed, but no labels and inputs

