### PR TITLE
Fix render textpic above

### DIFF
--- a/Resources/Private/Templates/ContentElements/TextmediaAbove.html
+++ b/Resources/Private/Templates/ContentElements/TextmediaAbove.html
@@ -4,9 +4,11 @@
 <f:section name="Main">
 
     <div class="textmedia textmedia-above">
-        <div class="textmedia-item textmedia-gallery">
-            <f:render partial="Media/Gallery" arguments="{_all}" />
-        </div>
+        <f:if condition="{files}">
+            <div class="textmedia-item textmedia-gallery">
+                <f:render partial="Media/Gallery" arguments="{_all}" />
+            </div>
+        </f:if>&
         <div class="textmedia-item textmedia-text">
             <f:render partial="Header/All" arguments="{_all}" />
             <f:format.html>{data.bodytext}</f:format.html>

--- a/Resources/Private/Templates/ContentElements/TextpicAbove.html
+++ b/Resources/Private/Templates/ContentElements/TextpicAbove.html
@@ -4,9 +4,11 @@
 <f:section name="Main">
 
     <div class="textpic textpic-above">
-        <div class="textpic-item textpic-gallery">
-            <f:render partial="Media/Gallery" arguments="{_all}" />
-        </div>
+        <f:if condition="{files}">
+            <div class="textpic-item textpic-gallery">
+                <f:render partial="Media/Gallery" arguments="{_all}" />
+            </div>
+        </f:if>
         <div class="textpic-item textpic-text">
             <f:render partial="Header/All" arguments="{_all}" />
             <f:format.html>{data.bodytext}</f:format.html>


### PR DESCRIPTION
# Pull Request

## Related Issues

* Resolves #1441

## Prerequisites

* [x] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS

## Description

Check if there are files before rendering the gallery container to prevent unused space above text.

## Steps to Validate

1. Add Textpic CE without addding an image
