### PR TITLE
Use language overlay if querying content_from_pid

### DIFF
--- a/Configuration/TypoScript/ContentElement/Helper/DynamicContent.typoscript
+++ b/Configuration/TypoScript/ContentElement/Helper/DynamicContent.typoscript
@@ -69,10 +69,15 @@ lib.dynamicContent {
             field = pageUid
             ifEmpty.data = TSFE:id
         }
-        contentFromPid.cObject = TEXT
+        contentFromPid.cObject = RECORDS
         contentFromPid.cObject {
-            data = DB:pages:{register:pageUid}:content_from_pid
-            data.insertData = 1
+            tables = pages
+            source.data = register:pageUid
+
+            conf.pages = TEXT
+            conf.pages.field = content_from_pid
+
+            dontCheckPid = 1
         }
         wrap.cObject = TEXT
         wrap.cObject {


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes #1447
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Since TYPO3 9 the field "Show content from page" can be different for each translation. The database field content_from_pid is only fetched in the default language. So if your translated page has a content_from_pid set but the default language not its not recognized.