### PR TITLE
feat: Add classes for plugin type

### DIFF
--- a/Classes/ViewHelpers/FrameViewHelper.php
+++ b/Classes/ViewHelpers/FrameViewHelper.php
@@ -46,6 +46,7 @@ class FrameViewHelper extends AbstractViewHelper
         $this->registerArgument('frameClass', 'string', '', false, 'default');
         $this->registerArgument('frameAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', false, []);
         $this->registerArgument('type', 'string', '', false, 'default');
+        $this->registerArgument('listType', 'string', 'Type of plugin');
         $this->registerArgument('size', 'string', '', false, 'default');
         $this->registerArgument('height', 'string', '', false, 'default');
         $this->registerArgument('layout', 'string', '', false, 'default');
@@ -72,6 +73,7 @@ class FrameViewHelper extends AbstractViewHelper
     ) {
         $configuration = $arguments;
         $configuration['type'] = trim((string) $configuration['type']) !== '' ? trim($configuration['type']) : 'default';
+        $configuration['listType'] = trim((string) $configuration['listType']);
         $configuration['frameClass'] = trim((string) $configuration['frameClass']) !== '' ? trim($configuration['frameClass']) : 'default';
         $configuration['frameAttributes'] = isset($configuration['frameAttributes']) && is_array($configuration['frameAttributes']) ? $configuration['frameAttributes'] : [];
         $configuration['size'] = trim((string) $configuration['size']) !== '' ? trim($configuration['size']) : 'default';
@@ -89,6 +91,9 @@ class FrameViewHelper extends AbstractViewHelper
         $classes[] = 'frame';
         $classes[] = 'frame-' . $configuration['frameClass'];
         $classes[] = 'frame-type-' . $configuration['type'];
+        if ($configuration['listType']) {
+            $classes[] = 'frame-type-list-' . $configuration['listType'];
+        }
         $classes[] = 'frame-layout-' . $configuration['layout'];
         $classes[] = 'frame-size-' . $configuration['size'];
         $classes[] = 'frame-height-' . $configuration['height'];

--- a/Resources/Private/Layouts/ContentElements/Default.html
+++ b/Resources/Private/Layouts/ContentElements/Default.html
@@ -19,6 +19,7 @@
 <bk2k:frame
     id="c{data.uid}"
     type="{data.CType}"
+    listType="{f:if(condition: '{data.CType} == \"list\"', then: data.list_type)}"
     size="default"
     layout="{data.frame_layout}"
     frameClass="{data.frame_class}"


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [x] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [x] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

It could be useful to know which plugin a frame contains. This pull requests adds this information (e.g. class "frame-type-list-indexedsearch_pi2") to the frame-div:

```
<div id="c149" class=" frame frame-default frame-type-list frame-type-list-indexedsearch_pi2 frame-layout-default frame-size-default frame-height-default frame-background-none frame-space-before-none frame-space-after-none frame-no-backgroundimage">
```

## Steps to Validate

1. Create a content element containing a plugin, e.g. plugin of EXT:indexed_search
2. Check HTML code in FE
