### PR TITLE
Simplify language and footer meta menu: Use list-inline instead of custom styles

### DIFF
--- a/Resources/Private/Partials/Page/Navigation/Language.html
+++ b/Resources/Private/Partials/Page/Navigation/Language.html
@@ -1,16 +1,16 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:if condition="{languagenavigation}">
-    <ul id="language_menu" class="language-menu">
+    <ul class="list-inline">
         <f:for each="{languagenavigation}" as="item">
-            <li class="{f:if(condition: item.active, then: 'active')} {f:if(condition: item.available, else: 'inactive')}">
+            <li class="list-inline-item{f:if(condition: item.active, then: ' active')}{f:if(condition: item.available, else: ' text-muted')}">
                 <f:if condition="{item.available}">
                     <f:then>
                         <a href="{item.link}" hreflang="{item.hreflang}" title="{item.title}">
-                            <span>{item.navigationTitle}</span>
+                            {item.navigationTitle}
                         </a>
                     </f:then>
                     <f:else>
-                        <span>{item.navigationTitle}</span>
+                        {item.navigationTitle}
                     </f:else>
                 </f:if>
             </li>

--- a/Resources/Private/Partials/Page/Navigation/Meta.html
+++ b/Resources/Private/Partials/Page/Navigation/Meta.html
@@ -1,10 +1,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:if condition="{metanavigation}">
-    <ul id="meta_menu" class="meta-menu">
+    <ul class="list-inline">
         <f:for each="{metanavigation}" as="item" iteration="metaiteration">
-            <li{f:if(condition: item.active, then:' class="active"')}>
-                <a href="{item.link}"{f:if(condition: '{item.target}', then: ' target="{item.target}"')}{f:if(condition: '{item.target} == "_blank"', then: ' rel="noopener noreferrer"')} title="{item.title}">
-                    <span>{item.title}</span>
+            <li class="list-inline-item{f:if(condition: item.active, then:' active')}">
+                <a href="{item.link}"{f:if(condition: item.target, then: ' target="{item.target}"')} title="{item.title}">
+                    {item.title}
                 </a>
             </li>
         </f:for>

--- a/Resources/Public/Scss/components/_footer.scss
+++ b/Resources/Public/Scss/components/_footer.scss
@@ -161,24 +161,9 @@ $footer-sections: map-merge(
 // Footer Language
 // --------------------------------------------------
 .footer-language {
-    .language-menu {
-        margin: 0;
-        list-style: none;
-        padding-left: 0;
-        @include media-breakpoint-up('sm') {
-            margin-left: -.5em;
-            margin-right: -.5em;
-            > li {
-                display: inline-block;
-                padding-left: .5em;
-                padding-right: .5em;
-            }
-        }
+    ul {
         .active a {
             font-weight: bold;
-        }
-        .inactive {
-            opacity: .5;
         }
     }
 }

--- a/Resources/Public/Scss/components/_footer.scss
+++ b/Resources/Public/Scss/components/_footer.scss
@@ -138,21 +138,9 @@ $footer-sections: map-merge(
 // Footer Meta
 // --------------------------------------------------
 .footer-meta {
-    .meta-menu {
-        margin: 0;
-        list-style: none;
-        padding-left: 0;
-        @include media-breakpoint-up('sm') {
-            margin-left: -.5em;
-            margin-right: -.5em;
-            > li {
-                display: inline-block;
-                padding-left: .5em;
-                padding-right: .5em;
-            }
-        }
+    ul {
         .active a {
-            font-weight: bold;
+            font-weight: $font-weight-bold;
         }
     }
 }

--- a/Resources/Public/Scss/components/_footer.scss
+++ b/Resources/Public/Scss/components/_footer.scss
@@ -163,7 +163,7 @@ $footer-sections: map-merge(
 .footer-language {
     ul {
         .active a {
-            font-weight: bold;
+            font-weight: $font-weight-bold;
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [x] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [x] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Simplifies language and footer meta menu by using Bootstrap class "list-inline" (nothing else is the language and footer meta menu right now) instead of custom styles.

## Steps to Validate

Check language and footer meta menu.
