### PR TITLE
[TASK] Avoid deprecated EMU::addPageTSConfig()

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -48,7 +48,7 @@ indent_size = 3
 max_line_length = 80
 
 # TypoScript
-[*.typoscript]
+[{*.typoscript,*.tsconfig}]
 indent_style = space
 indent_size = 4
 

--- a/Classes/ExpressionLanguage/ConditionProvider.php
+++ b/Classes/ExpressionLanguage/ConditionProvider.php
@@ -22,6 +22,7 @@ class ConditionProvider extends AbstractProvider
     {
         $this->expressionLanguageVariables = [
             'extension' => GeneralUtility::makeInstance(ExtensionWrapper::class),
+            'extensionConfiguration' => GeneralUtility::makeInstance(ExtensionConfigurationWrapper::class),
         ];
     }
 }

--- a/Classes/ExpressionLanguage/ExtensionConfigurationWrapper.php
+++ b/Classes/ExpressionLanguage/ExtensionConfigurationWrapper.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\ExpressionLanguage;
+
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+
+#[Autoconfigure(public: true)]
+final class ExtensionConfigurationWrapper
+{
+    public function __construct(
+        private readonly ExtensionConfiguration $extensionConfiguration,
+    ) {
+    }
+
+    /**
+     * True if a bool toggle in ext_conf_template is true'ish.
+     */
+    public function isToggleEnabled(string $extensionKey, string $extConfTemplateToggle): bool
+    {
+        return (bool)$this->extensionConfiguration->get($extensionKey, $extConfTemplateToggle);
+    }
+}

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,29 @@
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsContentElements')]
+    # Add Content Elements
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/ContentElement/All.tsconfig'
+[end]
+
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsBackendLayouts')]
+    # Add BackendLayouts for the BackendLayout DataProvider
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts.tsconfig'
+[end]
+
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsRTE')]
+    # RTE
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/RTE.tsconfig'
+[end]
+
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsTCADefaults')]
+    # TCADefaults
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/TCADefaults.tsconfig'
+[end]
+
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsTCEMAIN')]
+    # TCEMAIN
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/TCEMAIN.tsconfig'
+[end]
+
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsTCEFORM')]
+    # TCEFORM
+    @import 'EXT:bootstrap_package/Configuration/TsConfig/Page/TCEFORM.tsconfig'
+[end]

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -18,38 +18,6 @@ $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
     \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
 );
 
-// PageTS
-
-// Add Content Elements
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsContentElements')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/ContentElement/All.tsconfig">');
-}
-
-// Add BackendLayouts for the BackendLayout DataProvider
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsBackendLayouts')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts.tsconfig">');
-}
-
-// RTE
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsRTE')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/RTE.tsconfig">');
-}
-
-// TCADefaults
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsTCADefaults')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/TCADefaults.tsconfig">');
-}
-
-// TCEMAIN
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsTCEMAIN')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/TCEMAIN.tsconfig">');
-}
-
-// TCEFORM
-if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disablePageTsTCEFORM')) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_package/Configuration/TsConfig/Page/TCEFORM.tsconfig">');
-}
-
 // Register custom EXT:form configuration
 if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('


### PR DESCRIPTION
Register own condition matcher to access ExtensionConfiguration toggles. Switch from INCLUDE_TYPOSCRIPT to @import.
