### PR TITLE
[BUGFIX] Remove use of removed ViewHelper usage in EXT:indexed_search

### DIFF
--- a/Resources/Private/Templates/IndexedSearch/Search/Search.html
+++ b/Resources/Private/Templates/IndexedSearch/Search/Search.html
@@ -27,7 +27,9 @@
         <f:if condition="{result.count} > 0">
             <f:then>
                 <p>
-                    <is:pageBrowsingResults numberOfResults="{result.count}" currentPage="{searchParams.pointer}" resultsPerPage="{searchParams.numberOfResults}" />
+                    <f:sanitize.html>
+                        <f:translate key="displayResults" arguments="{0: result.pagination.startRecordNumber, 1: result.pagination.endRecordNumber, 2: result.count}" />
+                    </f:sanitize.html>
                     {result.sectionText}
                 </p>
                 <!-- render the anchor-links to the sections inside the displayed result rows -->
@@ -64,7 +66,7 @@
                         </f:else>
                     </f:if>
                 </f:for>
-                <is:pageBrowsing numberOfResults="{result.count}" maximumNumberOfResultPages="{settings.page_links}" currentPage="{searchParams.pointer}" resultsPerPage="{searchParams.numberOfResults}" />
+                <f:render partial="Pagination" arguments="{pagination: result.pagination, searchParams: searchParams, freeIndexUid: freeIndexUid}" />
             </f:then>
             <f:else>
                 <div class="alert alert-info">


### PR DESCRIPTION
With https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102945-PaginationOfIndexedSearchReplaced.html the ViewHelpers `is:pageBrowsingResults` and `is:pageBrowsing` have been removed.

bootstrap_package for TYPO3 v13 needs adaption to prevent a PHP error when using the adapted indexed_search template.

This has also been reported with:

* https://forge.typo3.org/issues/105562
* https://github.com/FriendsOfTYPO3/introduction/issues/115

The latter needs to be updated to a new release of EXT:bootstrap_package once this bugfix has been merged.

I do not know / did not check, if this
template would work in TYPO3 v12, so maybe a different template needs to be used for TYPO3 v12.

Releases: master, BP 15.x
