### PR TITLE
[BUGFIX] #1479 Wrong image width in containers when nesting containers

### DIFF
--- a/Resources/Private/Layouts/ContentElements/Default.html
+++ b/Resources/Private/Layouts/ContentElements/Default.html
@@ -6,13 +6,15 @@
     <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{columnConfig.multiplier}" gutters="{columnConfig.gutters}" corrections="{columnConfig.corrections}" />
 </f:if>
 
+<f:variable name="colPos" value="{data.colPos}" />
 <f:if condition="{containerContext}">
-    <f:for each="{containerContext}" as="context">
+    <f:for each="{containerContext}" as="context" reverse="1">
         <f:variable name="containerConfig">{settings.responsiveimages.container.{context.CType}}</f:variable>
-        <f:variable name="containerColumnConfig">{containerConfig.{data.colPos}}</f:variable>
+        <f:variable name="containerColumnConfig">{containerConfig.{colPos}}</f:variable>
         <f:if condition="{containerColumnConfig}">
             <bk2k:data.imageVariants as="variants" variants="{variants}" multiplier="{containerColumnConfig.multiplier}" gutters="{containerColumnConfig.gutters}" corrections="{containerColumnConfig.corrections}" />
         </f:if>
+        <f:variable name="colPos" value="{context.colPos}" />
     </f:for>
 </f:if>
 


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1479 [bug]

## Prerequisites

* [x ] Changes have been tested on TYPO3 v12.4 LTS
* [x ] Changes have been tested on PHP 8.2

## Description

The layout used the colPos of the Contentelement for each Container. If you used a 75/25 container and placed a 50/50 container inside the 75% column, the images are calculated with multiplier 0.75 * 0.75 for the left image and 0.25 * 0.25 for the right image.

Instead of this, the colPos of the container has to be respected in calculation. And that´s what this Fix does.

## Steps to Validate

1. place a 75/25 Container somwhere on the page
2. place a 50/50 container inside the 75% column of the previous container
3. place TextMedia-Elements with images inside both columns of the 50/50 container

The right image will be blurry, because the 0.25 multiplier of the outer container is also used for calculating the 50/50 container.

After this fix, both images are calculated the right way and both are the same size.