### PR TITLE
Overflow prevents position:sticky

### DIFF
--- a/Resources/Public/Scss/components/_section.scss
+++ b/Resources/Public/Scss/components/_section.scss
@@ -2,7 +2,7 @@
 // Section
 // --------------------------------------------------
 .section {
-    overflow: hidden;
+    overflow: clip;
 }
 .section-row {
     --section-columns: 12;


### PR DESCRIPTION
# Pull Request

I tried to set a table header to `position:sticky` but it didn't work.
I found out that a `overflow:hidden` prevents this.
After changen
```
.section {
  overflow: hidden;
}
```
to
```
.section {
  overflow: clip;
}
```
it worked.

Are there any drawbacks?
