### PR TITLE
Updated templateRootPath folders

### DIFF
--- a/Configuration/Sets/Full/settings.definitions.yaml
+++ b/Configuration/Sets/Full/settings.definitions.yaml
@@ -605,7 +605,7 @@ settings:
     label: 'Template Root Path'
     category: BootstrapPackage.templates.page
     type: string
-    default: 'EXT:bootstrap_package/Resources/Private/Partials/Page/'
+    default: 'EXT:bootstrap_package/Resources/Private/Templates/Page/'
 
   # Template Block
   plugin.bootstrap_package_blocks.view.layoutRootPath:
@@ -624,7 +624,7 @@ settings:
     label: 'Template Root Path'
     category: BootstrapPackage.templates.block
     type: string
-    default: 'EXT:bootstrap_package/Resources/Private/Partials/Blocks/'
+    default: 'EXT:bootstrap_package/Resources/Private/Templates/Blocks/'
 
   # Template Plugin
   plugin.bootstrap_package.view.layoutRootPath:
@@ -643,7 +643,7 @@ settings:
     label: 'Template Root Path'
     category: BootstrapPackage.templates.plugin
     type: string
-    default: 'EXT:bootstrap_package/Resources/Private/Partials/'
+    default: 'EXT:bootstrap_package/Resources/Private/Templates/'
 
   # Settings
   plugin.bootstrap_package.settings.cssSourceMapping:


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Probably a copy-paste issue - all template root paths pointed to the partials folder. I can't currently test it but looking at originating commit https://github.com/benjaminkott/bootstrap_package/commit/01ed74bd8df1715d9dc2ce0c9aa30cf51ba8ae3e#diff-ddd1bfabb1769af3a562fa387512a32d01c80b3285bbbce9f5db5d1f4c11d83b the old code always pointed to .../Templates/ 