### PR TITLE
TYPO3 13 uses TypoScript sets

### DIFF
--- a/Documentation/QuickStart/Index.rst
+++ b/Documentation/QuickStart/Index.rst
@@ -33,8 +33,8 @@ elements that are not supported by these system extensions.
 Make sure you have a root page
 ==============================
 
-Create a new page or edit an existing one and set this as *root page*. You can
-find this option in the :ref:`Edit Page <t3editors:pages-properties>` mode filed
+Create a new page or edit an existing one and set this as *root page*. This is done by turning on the option
+:guilabel:`Use as Root Page` in the :ref:`Edit Page <t3editors:pages-properties>` 
 under :guilabel:`Behavior > Miscellaneous`.
 
 
@@ -50,17 +50,17 @@ General
 Options
 -------
 
-* Clear constants and setup by checking the boxes.
-* Clear the predefined TypoScript setup from the text box if any.
-* Use this template as root-level template by checking the box.
+* Clear constants and setup by checking their boxes.
+* Clear the predefined TypoScript setup from its text box if any.
+* Use this template as root-level template by checking the Rootlevel box.
 
 Includes
 --------
 
-Include static (from extensions)
+Include TypoScript sets
 
 * Bootstrap Package (required)
 
-Static Template Files from TYPO3 Extensions
+Loading order of TypoScript sets
 
-* Include before all static templates if root flag is set
+* Default (include before if root flag is set)


### PR DESCRIPTION
No "include static from extensions" is available in TYPO3 13.

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
