### PR TITLE
[BUGFIX] Correct width for wide icons preventing cutting off parts

### DIFF
--- a/Resources/Public/Scss/components/_sociallink.scss
+++ b/Resources/Public/Scss/components/_sociallink.scss
@@ -26,7 +26,7 @@
     font-size: 1.25rem;
     text-align: center;
     opacity: .8;
-    width: 1.25rem;
+    width: 1.75rem;
     height: 1.25rem;
     flex-shrink: 0;
     justify-content: center;


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [x] Changes have been tested on TYPO3 v13.4.9
* [x] Changes have been tested on PHP 8.3
* [x] CSS has been rebuilt (only if there are SCSS changes cd Build; npm ci; npm run build)

## Description

As some icons are not square, they are cut off at the edge. Widening the sociallinks-link-icon colum by .5rem fixes the issue.
