### PR TITLE
Fix import paths of page TSconfig for backend layouts

### DIFF
--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/2_columns.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/2_columns.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_25_75.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_25_75.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_25_75.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_25_75.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_50_50.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_50_50.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_50_50.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_50_50.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_offset_right.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/2_columns_offset_right.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_offset_right.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/2_columns_offset_right.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/3_columns.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/3_columns.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/3_columns.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/3_columns.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/default.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/default.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/default.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/default.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/simple.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/simple.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/simple.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/simple.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/special_feature.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/special_feature.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/special_feature.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/special_feature.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/special_start.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/special_start.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/special_start.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/special_start.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_left.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_left.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_left.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_left.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_left_2_columns.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_left_2_columns.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_left_2_columns.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_left_2_columns.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_right.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_right.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_right.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_right.tsconfig'

--- a/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_right_2_columns.tsconfig
+++ b/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts/subnavigation_right_2_columns.tsconfig
@@ -1,1 +1,1 @@
-@import 'EXT:bootstrap_package/Configuration/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_right_2_columns.tsconfig'
+@import 'EXT:bootstrap_package/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts/subnavigation_right_2_columns.tsconfig'


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1572 

## Prerequisites

* [x] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on TYPO3 v13.4 LTS

## Description

Fixed the import by adding the missing **Sets/** in the paths.
