### PR TITLE
[BUGFIX] Fix image width calculation in ImageVariantsUtility.php

### DIFF
--- a/Classes/Utility/ImageVariantsUtility.php
+++ b/Classes/Utility/ImageVariantsUtility.php
@@ -67,11 +67,11 @@ class ImageVariantsUtility
         $variants = $variants !== null ? $variants : [];
         $variants = self::processVariants($variants);
         $variants = self::processResolutions($variants);
-        if ($gutters !== null) {
-            $variants = self::removeGutters($variants, $gutters);
-        }
         if ($multiplier !== null) {
             $variants = self::processMultiplier($variants, $multiplier);
+        }
+        if ($gutters !== null) {
+            $variants = self::removeGutters($variants, $gutters);
         }
         if ($corrections !== null) {
             $variants = self::processCorrections($variants, $corrections);
@@ -178,7 +178,7 @@ class ImageVariantsUtility
     {
         foreach ($gutters as $variant => $value) {
             if (is_numeric($value) && $value > 0 && isset($variants[$variant]['width'])) {
-                $variants[$variant]['width'] = (int) ceil($variants[$variant]['width'] - (float) $value);
+                $variants[$variant]['width'] = (int) ceil($variants[$variant]['width'] - ((float) $value / 2));
             }
         }
         return $variants;


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1576

## Prerequisites

* [ X] Changes have been tested on TYPO3 v11.5 LTS
* [ X] Changes have been tested on TYPO3 v12.4 LTS
* [ X] Changes have been tested on TYPO3 v13 LTS
* [ X] Changes have been tested on PHP 8.0
* [ X] Changes have been tested on PHP 8.1
* [ X] Changes have been tested on PHP 8.2
* [ X] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

To reflect the calculation of image/text widths used in SCSS in PHP code, the multiplier must first be applied and then half of the gutter subtracted.
