### PR TITLE
[TASK] Remove PHPUnit deprecations

### DIFF
--- a/Build/phpunit-functional.xml
+++ b/Build/phpunit-functional.xml
@@ -1,28 +1,25 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
   backupGlobals="true"
   bootstrap="../.build/vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTestsBootstrap.php"
   colors="true"
-  convertErrorsToExceptions="true"
-  convertWarningsToExceptions="true"
-  forceCoversAnnotation="false"
   stopOnError="false"
   stopOnFailure="false"
   stopOnIncomplete="false"
   stopOnSkipped="false"
-  verbose="false"
   beStrictAboutTestsThatDoNotTestAnything="false"
->
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../Classes/</directory>
-    </include>
-  </coverage>
+  cacheDirectory=".phpunit.cache"
+  requireCoverageMetadata="false">
   <testsuites>
     <testsuite name="bk2k-bootstrap-package-functional-tests">
       <directory>../Tests/Functional</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../Classes/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/Build/phpunit-unit.xml
+++ b/Build/phpunit-unit.xml
@@ -1,28 +1,25 @@
 <?xml version="1.0"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
   backupGlobals="true"
   colors="true"
-  convertErrorsToExceptions="true"
-  convertWarningsToExceptions="true"
-  forceCoversAnnotation="false"
   processIsolation="false"
   stopOnError="false"
   stopOnFailure="false"
   stopOnIncomplete="false"
   stopOnSkipped="false"
-  verbose="false"
   beStrictAboutTestsThatDoNotTestAnything="true"
->
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">../Classes/</directory>
-    </include>
-  </coverage>
+  cacheDirectory=".phpunit.cache"
+  requireCoverageMetadata="false">
   <testsuites>
     <testsuite name="bk2k-bootstrap-package-unit-tests">
       <directory>../Tests/Unit</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">../Classes/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/Tests/Unit/Compiler/ScssCompilerTest.php
+++ b/Tests/Unit/Compiler/ScssCompilerTest.php
@@ -9,6 +9,7 @@
 
 namespace BK2K\BootstrapPackage\Tests\Unit\Compiler;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use ScssPhp\ScssPhp\Compiler;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -17,13 +18,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class ScssCompilerTest extends UnitTestCase
 {
-    /**
-     * @param string $file
-     * @param string $expectedResultFile
-     * @dataProvider compileDataProvider
-     * @test
-     */
-    public function compile(string $file, string $expectedResultFile): void
+    #[DataProvider('compileDataProvider')]
+    public function testCompile(string $file, string $expectedResultFile): void
     {
         $scss = new Compiler();
         $resultCss = $scss->compileString((string) file_get_contents(__DIR__ . '/' . $file), $file)->getCss();

--- a/Tests/Unit/DataProcessing/SkiplinkProcessorTest.php
+++ b/Tests/Unit/DataProcessing/SkiplinkProcessorTest.php
@@ -10,6 +10,7 @@
 namespace BK2K\BootstrapPackage\Tests\Unit\DataProcessing;
 
 use BK2K\BootstrapPackage\DataProcessing\SkiplinkProcessor;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\DependencyInjection\Container;
 use TYPO3\CMS\Frontend\ContentObject\ContentDataProcessor;
@@ -35,11 +36,8 @@ class SkiplinkProcessorTest extends UnitTestCase
         );
     }
 
-    /**
-     * @dataProvider getProcessDataProvider
-     * @test
-     */
-    public function process(array $setup, array $expectation): void
+    #[DataProvider('getProcessDataProvider')]
+    public function testProcess(array $setup, array $expectation): void
     {
         $contentObjectRendererStub = new ContentObjectRenderer();
         $config = [

--- a/Tests/Unit/Utility/ExternalMediaUtilityTest.php
+++ b/Tests/Unit/Utility/ExternalMediaUtilityTest.php
@@ -10,6 +10,7 @@
 namespace BK2K\BootstrapPackage\Tests\Unit\Utility;
 
 use BK2K\BootstrapPackage\Utility\ExternalMediaUtility;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -17,15 +18,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class ExternalMediaUtilityTest extends UnitTestCase
 {
-    /**
-     * @param string $url
-     * @param string $class
-     * @param string $title
-     * @param string $expectedResult
-     * @dataProvider getEmbedCodeDataProvider
-     * @test
-     */
-    public function getEmbedCode(?string $url, ?string $class, ?string $title, $expectedResult): void
+    #[DataProvider('getEmbedCodeDataProvider')]
+    public function testGetEmbedCode(?string $url, ?string $class, ?string $title, ?string $expectedResult): void
     {
         self::assertSame($expectedResult, (new ExternalMediaUtility())->getEmbedCode($url, $class, $title));
     }

--- a/Tests/Unit/Utility/ImageVariantsUtilityTest.php
+++ b/Tests/Unit/Utility/ImageVariantsUtilityTest.php
@@ -10,6 +10,7 @@
 namespace BK2K\BootstrapPackage\Tests\Unit\Utility;
 
 use BK2K\BootstrapPackage\Utility\ImageVariantsUtility;
+use PHPUnit\Framework\Attributes\DataProvider;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -17,13 +18,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  */
 class ImageVariantsUtilityTest extends UnitTestCase
 {
-    /**
-     * @param array $data
-     * @param array $expectedResult
-     * @dataProvider getImageVariantsTestDataProvider
-     * @test
-     */
-    public function getImageVariantsTest(array $data, array $expectedResult): void
+    #[DataProvider('getImageVariantsTestDataProvider')]
+    public function testGetImageVariantsTest(array $data, array $expectedResult): void
     {
         $variants = isset($data['variants']) ? $data['variants'] : null;
         $multiplier = isset($data['multiplier']) ? $data['multiplier'] : null;
@@ -930,13 +926,8 @@ class ImageVariantsUtilityTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @param array $data
-     * @param array $expectedResult
-     * @dataProvider getStackedImageVariantsTestDataProvider
-     * @test
-     */
-    public function getStackedImageVariantsTest(array $data, array $expectedResult): void
+    #[DataProvider('getStackedImageVariantsTestDataProvider')]
+    public function testGetStackedImageVariantsTest(array $data, array $expectedResult): void
     {
         $result = null;
         foreach ($data as $datasetKey => $datasetConfig) {
@@ -1039,13 +1030,8 @@ class ImageVariantsUtilityTest extends UnitTestCase
         ];
     }
 
-    /**
-     * @param mixed $input
-     * @param bool $expectedResult
-     * @dataProvider isValidSizeKeyTestDataProvider
-     * @test
-     */
-    public function isValidSizeKeyTest($input, bool $expectedResult): void
+    #[DataProvider('isValidSizeKeyTestDataProvider')]
+    public function testIsValidSizeKeyTest(mixed $input, bool $expectedResult): void
     {
         $result = ImageVariantsUtility::isValidSizeKey($input);
         self::assertSame($expectedResult, $result);


### PR DESCRIPTION
# Pull Request

## Prerequisites

* [x] Changes have been tested on TYPO3 v13.4 LTS
* [ ] Changes have been tested on TYPO3 v14
* [x] Changes have been tested on PHP 8.2
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`

## Description

Updating PHPUnit configuration files and migrate tests from annotations to attributes.

