### PR TITLE
[BUGFIX] SiteSets must respect the disablePageTsBackendLayout option

### DIFF
--- a/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts.tsconfig
+++ b/Configuration/Sets/BackendLayouts/PageTsConfig/BackendLayouts.tsconfig
@@ -1,2 +1,3 @@
-@import './BackendLayouts/'
-
+[!extensionConfiguration.isToggleEnabled('bootstrap_package', 'disablePageTsBackendLayouts')]
+    @import './BackendLayouts/'
+[end]


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [x] Changes have been tested on TYPO3 v13.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been tested on PHP 8.3
* [x] Changes have been tested on PHP 8.4
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

If you're in a SiteSets only installation, disabling backend layouts should be respected.

## Steps to Validate

1. [SiteSets configuration]
- Set "bootstrap-package/full" as SiteSet dependency in your sitepackage extension

2. [TypoScript configuration]
- Remove all manual TypoScript imports regarding Bootstrap Package

3. [Check backend layouts]
- Check if the default backend layouts are displayed in the page properties in "Appearance" tab