### PR TITLE
[TASK] Add referrerpolicy attribute to media

### DIFF
--- a/Classes/Utility/ExternalMediaUtility.php
+++ b/Classes/Utility/ExternalMediaUtility.php
@@ -29,7 +29,7 @@ class ExternalMediaUtility
      * Get the embed code for the given url if possible
      * and add a css class on the iframe
      */
-    public function getEmbedCode(?string $url, ?string $class, ?string $title = null): ?string
+    public function getEmbedCode(?string $url, ?string $class, ?string $title = null, ?string $referrerPolicy = null): ?string
     {
         if ($url === null || $url === '') {
             return null;
@@ -51,6 +51,9 @@ class ExternalMediaUtility
                 }
                 if ($class !== null && trim($class) !== '') {
                     $attributes['class'] = trim($class);
+                }
+                if ($referrerPolicy !== null && trim($referrerPolicy) !== '') {
+                    $attributes['referrerpolicy'] = trim($referrerPolicy);
                 }
                 return '<iframe ' . GeneralUtility::implodeAttributes($attributes, true) . ' allowfullscreen></iframe>';
             }

--- a/Classes/ViewHelpers/ExternalMediaViewHelper.php
+++ b/Classes/ViewHelpers/ExternalMediaViewHelper.php
@@ -29,6 +29,7 @@ class ExternalMediaViewHelper extends AbstractViewHelper
         $this->registerArgument('title', 'string', 'External media iframe title');
         $this->registerArgument('url', 'string', 'External media url');
         $this->registerArgument('class', 'string', 'CSS class rendered on the generated iframe code');
+        $this->registerArgument('referrerpolicy', 'string', 'Referrer policy rendered on the generated iframe code');
     }
 
     /**
@@ -49,7 +50,7 @@ class ExternalMediaViewHelper extends AbstractViewHelper
         }
         $variableProvider = $renderingContext->getVariableProvider();
         $externalMediaUtility = GeneralUtility::makeInstance(ExternalMediaUtility::class);
-        $externalMedia = $externalMediaUtility->getEmbedCode($this->arguments['url'], $this->arguments['class'], $this->arguments['title']);
+        $externalMedia = $externalMediaUtility->getEmbedCode($this->arguments['url'], $this->arguments['class'], $this->arguments['title'], $this->arguments['referrerpolicy']);
         $variableProvider->add('externalMedia', $externalMedia);
         $content = $this->renderChildren();
         $variableProvider->remove('externalMedia');

--- a/Classes/ViewHelpers/File/IsOnlineMediaViewHelper.php
+++ b/Classes/ViewHelpers/File/IsOnlineMediaViewHelper.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\ViewHelpers\File;
+
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\FileReference;
+use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperRegistry;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+class IsOnlineMediaViewHelper extends AbstractViewHelper
+{
+    /**
+     * @return bool
+     */
+    public function render()
+    {
+        $file = $this->renderChildren();
+
+        return is_object($file)
+            && ($file instanceof FileReference || $file instanceof File)
+            && GeneralUtility::makeInstance(OnlineMediaHelperRegistry::class)->hasOnlineMediaHelper($file->getExtension());
+    }
+}

--- a/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript
+++ b/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript
@@ -93,6 +93,9 @@ lib.contentElement {
                 modestbranding = {$plugin.bootstrap_package_contentelements.media.additionalConfig.modestbranding}
                 no-cookie = {$plugin.bootstrap_package_contentelements.media.additionalConfig.nocookie}
             }
+            additionalAttributes {
+                referrerpolicy = {$plugin.bootstrap_package_contentelements.media.additionalAttributes.referrerpolicy}
+            }
         }
         gallery {
             columns {

--- a/Configuration/Sets/ContentElements/settings.definitions.yaml
+++ b/Configuration/Sets/ContentElements/settings.definitions.yaml
@@ -163,6 +163,12 @@ settings:
     type: bool
     default: true
 
+  plugin.bootstrap_package_contentelements.media.additionalAttributes.referrerpolicy:
+    label: 'Referrer Policy'
+    category: BootstrapPackage.content-elements.media
+    type: string
+    default: 'strict-origin-when-cross-origin'
+
   # Gallery
   plugin.bootstrap_package_contentelements.gallery.columns.1.class:
     label: 'Item CSS Class for 1 column'

--- a/Configuration/Sets/ContentElements/settings.definitions.yaml
+++ b/Configuration/Sets/ContentElements/settings.definitions.yaml
@@ -165,6 +165,7 @@ settings:
 
   plugin.bootstrap_package_contentelements.media.additionalAttributes.referrerpolicy:
     label: 'Referrer Policy'
+    description: 'Referrer policy handed to embedded online media, for example strict-origin-when-cross-origin or no-referrer. Empty leaves the referrer policy of the site in place.'
     category: BootstrapPackage.content-elements.media
     type: string
     default: 'strict-origin-when-cross-origin'

--- a/Resources/Private/Partials/ContentElements/Media/Rendering/Video.html
+++ b/Resources/Private/Partials/ContentElements/Media/Rendering/Video.html
@@ -1,3 +1,3 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:media class="embed-responsive-item" file="{file}" alt="{file.properties.alternative}" title="{file.properties.title}" additionalConfig="{settings.media.additionalConfig}" />
+<f:media class="embed-responsive-item" file="{file}" alt="{file.properties.alternative}" title="{file.properties.title}" additionalConfig="{settings.media.additionalConfig}" additionalAttributes="{settings.media.additionalAttributes}" />
 </html>

--- a/Resources/Private/Partials/ContentElements/Media/Rendering/Video.html
+++ b/Resources/Private/Partials/ContentElements/Media/Rendering/Video.html
@@ -1,3 +1,12 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
-<f:media class="embed-responsive-item" file="{file}" alt="{file.properties.alternative}" title="{file.properties.title}" additionalConfig="{settings.media.additionalConfig}" additionalAttributes="{settings.media.additionalAttributes}" />
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:bk2k="http://typo3.org/ns/BK2K/BootstrapPackage/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:variable name="isOnlineMedia" value="{file -> bk2k:file.isOnlineMedia()}" />
+<f:comment>
+    Online media renders as an iframe, a local video as a video tag. referrerpolicy
+    is defined on the iframe and not on the video element, so it is only handed over
+    for the former.
+</f:comment>
+<f:if condition="{isOnlineMedia} && {settings.media.additionalAttributes.referrerpolicy}">
+    <f:variable name="mediaAttributes" value="{referrerpolicy: settings.media.additionalAttributes.referrerpolicy}" />
+</f:if>
+<f:media class="embed-responsive-item" file="{file}" alt="{file.properties.alternative}" title="{file.properties.title}" additionalConfig="{settings.media.additionalConfig}" additionalAttributes="{mediaAttributes}" />
 </html>

--- a/Resources/Private/Templates/ContentElements/ExternalMedia.html
+++ b/Resources/Private/Templates/ContentElements/ExternalMedia.html
@@ -2,7 +2,7 @@
 <f:layout name="Default" />
 <f:section name="Main">
 
-    <bk2k:externalMedia title="{data.external_media_title}" url="{data.external_media_source}" class="embed-responsive-item">
+    <bk2k:externalMedia title="{data.external_media_title}" url="{data.external_media_source}" class="embed-responsive-item" referrerpolicy="{settings.media.additionalAttributes.referrerpolicy}">
         <f:if condition="{externalMedia}">
             <f:then>
                 <div class="embed-responsive embed-responsive-{data.external_media_ratio}">

--- a/Tests/Functional/ContentElements/Fixtures/Media/pages.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Media/pages.csv
@@ -1,0 +1,6 @@
+"pages",,,,,
+,"uid","pid","sorting","doktype","slug","title"
+,1,0,256,1,"/","Referrer policy configured"
+,11,1,256,1,"/online-media","Online media"
+,12,1,512,1,"/local-video","Local video"
+,2,0,512,1,"/","Referrer policy empty"

--- a/Tests/Functional/ContentElements/Fixtures/Media/setup-without-referrerpolicy.typoscript
+++ b/Tests/Functional/ContentElements/Fixtures/Media/setup-without-referrerpolicy.typoscript
@@ -1,0 +1,23 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Element/Textmedia.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+lib.contentElement.settings.media.additionalAttributes.referrerpolicy =
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+            where = colPos = 0
+        }
+        renderObj < tt_content.textmedia
+    }
+}

--- a/Tests/Functional/ContentElements/Fixtures/Media/setup.typoscript
+++ b/Tests/Functional/ContentElements/Fixtures/Media/setup.typoscript
@@ -1,0 +1,23 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Element/Textmedia.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+lib.contentElement.settings.media.additionalAttributes.referrerpolicy = strict-origin-when-cross-origin
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+            where = colPos = 0
+        }
+        renderObj < tt_content.textmedia
+    }
+}

--- a/Tests/Functional/ContentElements/Fixtures/Media/tt_content.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Media/tt_content.csv
@@ -1,0 +1,5 @@
+"tt_content",,,,,,
+,"uid","pid","sorting","CType","colPos","assets"
+,1,11,256,"textmedia",0,1
+,2,12,256,"textmedia",0,1
+,3,2,256,"textmedia",0,1

--- a/Tests/Functional/ContentElements/MediaTest.php
+++ b/Tests/Functional/ContentElements/MediaTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\ContentElements;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the referrer policy handed to the media rendering
+ *
+ * @see Resources/Private/Partials/ContentElements/Media/Rendering/Video.html
+ */
+final class MediaTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    private ResourceStorage $storage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Media/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Media/tt_content.csv');
+
+        $storageRepository = $this->get(StorageRepository::class);
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/');
+        $this->storage = $storageRepository->findByUid(
+            $storageRepository->createLocalStorage('fixture', 'fileadmin/', 'relative', '', true)
+        );
+
+        $onlineMedia = $this->createFile('video.youtube', 'zpOVYePk6mM');
+        $this->attachToContentElement($onlineMedia, 1, 11);
+        $this->attachToContentElement($this->createFile('video.mp4', self::MP4_HEADER), 2, 12);
+        $this->attachToContentElement($onlineMedia, 3, 2);
+
+        $this->writeSite(1, 'http://localhost/');
+        $this->writeSite(2, 'http://localhost2/');
+
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/ContentElements/Fixtures/Media/setup.typoscript',
+        ]);
+        $this->setUpFrontendRootPage(2, [
+            'EXT:bootstrap_package/Tests/Functional/ContentElements/Fixtures/Media/setup-without-referrerpolicy.typoscript',
+        ]);
+    }
+
+    /**
+     * Online media renders through an iframe, which is what the referrer policy
+     * is defined on.
+     */
+    #[Test]
+    public function onlineMediaCarriesTheConfiguredReferrerPolicy(): void
+    {
+        $markup = $this->renderPage('http://localhost/index.php?id=11');
+
+        self::assertStringContainsString('<iframe', $markup);
+        self::assertStringContainsString('referrerpolicy="strict-origin-when-cross-origin"', $markup);
+    }
+
+    /**
+     * A local video renders through a video tag, where referrerpolicy is not a
+     * defined attribute and would only be invalid markup.
+     */
+    #[Test]
+    public function localVideoCarriesNoReferrerPolicy(): void
+    {
+        $markup = $this->renderPage('http://localhost/index.php?id=12');
+
+        self::assertStringContainsString('<video', $markup);
+        self::assertStringNotContainsString('referrerpolicy', $markup);
+    }
+
+    #[Test]
+    public function emptyReferrerPolicyRendersNoAttribute(): void
+    {
+        $markup = $this->renderPage('http://localhost2/index.php?id=2');
+
+        self::assertStringContainsString('<iframe', $markup);
+        self::assertStringNotContainsString('referrerpolicy', $markup);
+    }
+
+    private function renderPage(string $url): string
+    {
+        $response = $this->executeFrontendSubRequest(new InternalRequest($url));
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    private function createFile(string $name, string $contents): File
+    {
+        file_put_contents($this->instancePath . '/fileadmin/' . $name, $contents);
+        $file = $this->storage->getFile('/' . $name);
+        self::assertInstanceOf(File::class, $file);
+
+        return $file;
+    }
+
+    private function attachToContentElement(File $file, int $contentElementId, int $pageId): void
+    {
+        $this->getConnectionPool()->getConnectionForTable('sys_file_reference')->insert(
+            'sys_file_reference',
+            [
+                'pid' => $pageId,
+                'uid_local' => $file->getUid(),
+                'uid_foreign' => $contentElementId,
+                'tablenames' => 'tt_content',
+                'fieldname' => 'assets',
+                'sorting_foreign' => 1,
+            ]
+        );
+    }
+
+    private function writeSite(int $rootPageId, string $base): void
+    {
+        $this->get(SiteWriter::class)->write('bootstrap-package-test-' . $rootPageId, [
+            'rootPageId' => $rootPageId,
+            'base' => $base,
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * The indexer reads the mime type off the file, and video/mp4 is what picks
+     * the video renderer.
+     */
+    private const MP4_HEADER = "\x00\x00\x00\x20ftypisom\x00\x00\x02\x00isomiso2avc1mp41";
+}

--- a/Tests/Unit/Utility/ExternalMediaUtilityTest.php
+++ b/Tests/Unit/Utility/ExternalMediaUtilityTest.php
@@ -102,4 +102,34 @@ class ExternalMediaUtilityTest extends UnitTestCase
             ],
         ];
     }
+
+    #[DataProvider('getEmbedCodeWithReferrerPolicyDataProvider')]
+    public function testGetEmbedCodeWithReferrerPolicy(?string $referrerPolicy, ?string $expectedResult): void
+    {
+        self::assertSame(
+            $expectedResult,
+            (new ExternalMediaUtility())->getEmbedCode('https://www.youtube.com/watch?v=zpOVYePk6mM', null, null, $referrerPolicy)
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public static function getEmbedCodeWithReferrerPolicyDataProvider(): array
+    {
+        return [
+            'with referrer policy' => [
+                'strict-origin-when-cross-origin',
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+            ],
+            'with referrer policy null' => [
+                null,
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>',
+            ],
+            'with referrer policy empty' => [
+                ' ',
+                '<iframe src="https://www.youtube-nocookie.com/embed/zpOVYePk6mM" frameborder="0" allowfullscreen></iframe>',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
## Description

Adds `referrerpolicy` to embedded media. A site that sends
`Referrer-Policy: same-origin` strips the referrer from the embed request,
and YouTube answers that with error 153. The element level attribute
overrides the document policy for that one fetch and brings the referrer
back.

The value comes from a new site set setting,
`plugin.bootstrap_package_contentelements.media.additionalAttributes.referrerpolicy`,
defaulting to `strict-origin-when-cross-origin` — the browser default, so a
site that sends no header of its own renders as before. An empty value
renders no attribute and leaves the referrer policy of the site in place.

`referrerpolicy` is defined on `iframe` and not on `video`. The media
rendering partial serves online media and locally hosted video alike, so it
asks `OnlineMediaHelperRegistry` which of the two it has and hands the
attribute over only for the former. The external media element builds its
iframe itself and reads the same setting.

## Type of change

* [x] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## Related issues

None.

## How to validate

1. Send `Referrer-Policy: same-origin` from the web server.
2. Reference a YouTube video in a media element: the iframe carries
   `referrerpolicy="strict-origin-when-cross-origin"` and the player loads
   instead of failing with error 153.
3. Reference an mp4 in a textmedia element: the `video` tag carries no
   `referrerpolicy`.
4. Empty the setting: neither carries the attribute.
5. `composer test` — `Tests/Functional/ContentElements/MediaTest.php` covers
   1 to 4 and fails without the change to the rendering partial.

## AI assistance

* Agent and version: Claude Code
* Model and effort/reasoning level: Claude Opus 5, high
* Share written by the agent: the first commit is hand written by the
  contributor. The three follow-up commits — the restriction to online
  media, the external media element and the setting description, with their
  tests — were written by the agent from a review of the first.
* Reviewed and understood before pushing: yes, by the maintainer

## Checklist

* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes
* [x] `composer test` passes
* [x] A bugfix comes with a test that fails without it — appreciated,
      not required
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [ ] Assets rebuilt and committed if SCSS, JavaScript or icons changed
      (`npm --prefix Build ci && npm --prefix Build run build`)
* [x] Documentation updated if the change is user facing
