### PR TITLE
[BUGFIX] Google font caching

### DIFF
--- a/Classes/Service/GoogleFontService.php
+++ b/Classes/Service/GoogleFontService.php
@@ -72,8 +72,6 @@ class GoogleFontService
         }
         $content = $response->getBody()->getContents();
 
-        $content = $response->getBody()->getContents();
-
         // Ensure cache directory exists
         GeneralUtility::mkdir_deep($this->getAbsoluteCacheDirectory($url));
 
@@ -117,7 +115,9 @@ class GoogleFontService
 
     protected function isValidHttpsUrl(string $url): bool
     {
-        return filter_var($url, FILTER_VALIDATE_URL) !== false
+        // as prior to TYPO3 v14 arguments were not encoded, and it's common to use whitespaces in Google font URLs,
+        // we'll replace them for now
+        return filter_var(str_replace(' ', '+', $url), FILTER_VALIDATE_URL) !== false
             && str_starts_with($url, 'https://');
     }
 

--- a/Tests/Unit/Service/GoogleFontServiceTest.php
+++ b/Tests/Unit/Service/GoogleFontServiceTest.php
@@ -42,6 +42,10 @@ class GoogleFontServiceTest extends UnitTestCase
                 'https://fonts.googleapis.com/css2?family=Open Sans:wght@400;700&display=swap',
                 true,
             ],
+            'valid Google Fonts URL with encoded white space and css2' => [
+                'https://fonts.googleapis.com/css2?family=Open%20Sans:wght@400;700&display=swap',
+                true,
+            ],
             'HTTP URL rejected' => [
                 'http://fonts.googleapis.com/css?family=Roboto',
                 false,

--- a/Tests/Unit/Service/GoogleFontServiceTest.php
+++ b/Tests/Unit/Service/GoogleFontServiceTest.php
@@ -38,6 +38,10 @@ class GoogleFontServiceTest extends UnitTestCase
                 'https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&display=swap',
                 true,
             ],
+            'invalid but common Google Fonts URL with white space and css2' => [
+                'https://fonts.googleapis.com/css2?family=Open Sans:wght@400;700&display=swap',
+                true,
+            ],
             'HTTP URL rejected' => [
                 'http://fonts.googleapis.com/css?family=Roboto',
                 false,


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1604

## Prerequisites

* [x] Changes have been tested on TYPO3 v13.4 LTS
* [x] Changes have been tested on TYPO3 v14.1
* [x] Changes have been tested on PHP 8.2
* [ ] Changes have been tested on PHP 8.3
* [x] Changes have been tested on PHP 8.4
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Currently, there are two issues with Google fonts caching:
1. Response stream is fetched twice, resulting in empty cache files.
2. In v13 validation of URLs fails with font family names containing white spaces as they were not properly encoded. Since white spaces are commonly used in Google fonts URLs, they are simply replaced.

## Steps to Validate

### Empty cache files

1. Install extension from master branch, keep default settings.
2. Check the generated cache file being empty.
3. Install extension from this branch, keep default settings.
4. Check the generated cache file containing desired content.

### No caching in v13 with white spaces in font family names

1. Install extension from master branch in v13, keep default settings.
2. Check the frontend loading fonts from fonts.googleapis.com.
3. Install extension from this branch in v13, keep default settings.
4. Check the frontend loading fonts from the cache file.
