### PR TITLE
[BUGFIX] Render table cells containing "0"

### DIFF
--- a/Resources/Private/Partials/ContentElements/Table/Columns.html
+++ b/Resources/Private/Partials/ContentElements/Table/Columns.html
@@ -43,7 +43,7 @@
     </f:else>
 </f:if>
 
-<f:if condition="{cell}">
+<f:if condition="{cell}!="">
     <f:then>
         <f:format.nl2br>{cell}</f:format.nl2br>
     </f:then>

--- a/Resources/Private/Partials/ContentElements/Table/Columns.html
+++ b/Resources/Private/Partials/ContentElements/Table/Columns.html
@@ -43,7 +43,7 @@
     </f:else>
 </f:if>
 
-<f:if condition="{cell}!="">
+<f:if condition="{cell} != ''">
     <f:then>
         <f:format.nl2br>{cell}</f:format.nl2br>
     </f:then>

--- a/Tests/Functional/ContentElements/Fixtures/Table/pages.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Table/pages.csv
@@ -1,0 +1,3 @@
+"pages",,,,,
+,"uid","pid","sorting","doktype","slug","title"
+,1,0,256,1,"/","Root"

--- a/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript
+++ b/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript
@@ -1,0 +1,21 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Element/Table.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+            where = colPos = 0
+        }
+        renderObj < tt_content.table
+    }
+}

--- a/Tests/Functional/ContentElements/Fixtures/Table/tt_content.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Table/tt_content.csv
@@ -1,0 +1,3 @@
+"tt_content",,,,,,,,
+,"uid","pid","sorting","CType","colPos","header","bodytext","table_delimiter","table_enclosure"
+,1,1,256,"table",0,"","0||text",124,0

--- a/Tests/Functional/ContentElements/TableTest.php
+++ b/Tests/Functional/ContentElements/TableTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\ContentElements;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the rendered cells of the table content element
+ *
+ * @see Resources/Private/Partials/ContentElements/Table/Columns.html
+ */
+final class TableTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Table/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Table/tt_content.csv');
+
+        $this->get(SiteWriter::class)->write('bootstrap-package-test', [
+            'rootPageId' => 1,
+            'base' => 'http://localhost/',
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript',
+        ]);
+    }
+
+    /**
+     * The row is "0||text": a cell carrying a zero, an empty cell and a cell
+     * carrying a word. A zero is falsy, so a condition on the cell alone drops
+     * it and the empty-cell fallback takes its place.
+     */
+    #[Test]
+    public function cellCarryingAZeroIsRendered(): void
+    {
+        self::assertStringContainsString(
+            '<td>0</td>',
+            $this->renderFrontendPage(1)
+        );
+    }
+
+    #[Test]
+    public function emptyCellFallsBackToANonBreakingSpace(): void
+    {
+        self::assertStringContainsString(
+            '<td>&nbsp;</td>',
+            $this->renderFrontendPage(1)
+        );
+    }
+
+    /**
+     * The template indents every cell across several lines, which says nothing
+     * about the rendered table, so the whitespace between the tags is removed
+     * before the assertions read it.
+     */
+    private function renderFrontendPage(int $pageId): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('http://localhost/index.php?id=' . $pageId)
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)preg_replace('/\s*(<[^>]++>)\s*/', '$1', (string)$response->getBody());
+    }
+}


### PR DESCRIPTION
The Value of 0 is never displayed in a Table, becase the condition is interpreted as "false" an thus &nbsp; is written to the output.

# Pull Request

## Related Issues

* Closes #
* Fixes # [bug]
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [ ] Changes have been tested on PHP 8.2
* [ ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

[Description of changes proposed in this pull request]

## Steps to Validate

1. [First Step]
2. [Second Step]
3. [and so on...]
