### PR TITLE
[BUGFIX][issue 1615] Fix: show space_after_class again in backend

### DIFF
--- a/Configuration/TCA/Overrides/300_content_general_columns.php
+++ b/Configuration/TCA/Overrides/300_content_general_columns.php
@@ -338,13 +338,15 @@ $GLOBALS['TCA']['tt_content']['columns']['subitems_header_layout'] = [
 ];
 
 // Add fields to default palettes
-$GLOBALS['TCA']['tt_content']['palettes']['frames']['showitem'] .= '
-    ,--linebreak--,
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addFieldsToPalette(
+    'tt_content',
+    'frames',
+    '--linebreak--,
     frame_layout,
     frame_options,
     --linebreak--,
     background_color_class,
     --linebreak--,
     background_image,
-    background_image_options,
-';
+    background_image_options'
+);

--- a/Configuration/TCA/Overrides/300_content_general_columns.php
+++ b/Configuration/TCA/Overrides/300_content_general_columns.php
@@ -339,7 +339,7 @@ $GLOBALS['TCA']['tt_content']['columns']['subitems_header_layout'] = [
 
 // Add fields to default palettes
 $GLOBALS['TCA']['tt_content']['palettes']['frames']['showitem'] .= '
-    --linebreak--,
+    ,--linebreak--,
     frame_layout,
     frame_options,
     --linebreak--,


### PR DESCRIPTION
# Pull Request

## Related Issues

* Closes #
* Fixes #1615
* Resolves # [feature/question]

## Prerequisites

* [ ] Changes have been tested on TYPO3 v11.5 LTS
* [ ] Changes have been tested on TYPO3 v12.4 LTS
* [X ] Changes have been tested on TYPO3 v14.3 LTS
* [ ] Changes have been tested on PHP 7.4
* [ ] Changes have been tested on PHP 8.0
* [ ] Changes have been tested on PHP 8.1
* [x ] Changes have been tested on PHP 8.2
* [x ] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [ ] CSS has been rebuilt (only if there are SCSS changes `cd Build; npm ci; npm run build`)

## Description

Fixes #1615
https://github.com/benjaminkott/bootstrap_package/issues/1615

By extending showitems without a beginning comma, the field `space_after_class` is not shown in content elements anymore. This fix adds the comma, and the fields is shown again.

## Steps to Validate

1. Open a content element in backend, 
2. go to tab "Appearance".
3. without fix: You won't see `space_after_class`
4. with fix you will see the field again
