### PR TITLE
[TASK] Declare package metadata in composer.json

### DIFF
--- a/Tests/Functional/Parser/ScssParserTest.php
+++ b/Tests/Functional/Parser/ScssParserTest.php
@@ -31,6 +31,8 @@ class ScssParserTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/TypoScript/DynamicContentTest.php
+++ b/Tests/Functional/TypoScript/DynamicContentTest.php
@@ -27,6 +27,8 @@ final class DynamicContentTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/AccordionContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/AccordionContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class AccordionContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/AccordionMediaOrientUpdateTest.php
+++ b/Tests/Functional/Updates/AccordionMediaOrientUpdateTest.php
@@ -23,6 +23,8 @@ final class AccordionMediaOrientUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/BackendLayoutUpdateTest.php
+++ b/Tests/Functional/Updates/BackendLayoutUpdateTest.php
@@ -23,6 +23,8 @@ final class BackendLayoutUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/BulletContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/BulletContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class BulletContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/CarouselContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/CarouselContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class CarouselContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/CarouselItemLayoutUpdateTest.php
+++ b/Tests/Functional/Updates/CarouselItemLayoutUpdateTest.php
@@ -23,6 +23,8 @@ final class CarouselItemLayoutUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/CarouselItemTypeUpdateTest.php
+++ b/Tests/Functional/Updates/CarouselItemTypeUpdateTest.php
@@ -23,6 +23,8 @@ final class CarouselItemTypeUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/ExternalMediaContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/ExternalMediaContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class ExternalMediaContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/FrameClassToBackgroundUpdateTest.php
+++ b/Tests/Functional/Updates/FrameClassToBackgroundUpdateTest.php
@@ -23,6 +23,8 @@ final class FrameClassToBackgroundUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/FrameClassToOptionsUpdateTest.php
+++ b/Tests/Functional/Updates/FrameClassToOptionsUpdateTest.php
@@ -23,6 +23,8 @@ final class FrameClassToOptionsUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/FrameClassUpdateTest.php
+++ b/Tests/Functional/Updates/FrameClassUpdateTest.php
@@ -25,6 +25,8 @@ final class FrameClassUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/ListGroupContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/ListGroupContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class ListGroupContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/PanelContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/PanelContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class PanelContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TabContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/TabContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class TabContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TabMediaOrientUpdateTest.php
+++ b/Tests/Functional/Updates/TabMediaOrientUpdateTest.php
@@ -23,6 +23,8 @@ final class TabMediaOrientUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TableContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/TableContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class TableContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TexticonContentElementUpdateTest.php
+++ b/Tests/Functional/Updates/TexticonContentElementUpdateTest.php
@@ -23,6 +23,8 @@ final class TexticonContentElementUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TexticonIconUpdateTest.php
+++ b/Tests/Functional/Updates/TexticonIconUpdateTest.php
@@ -23,6 +23,8 @@ final class TexticonIconUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TexticonSizeUpdateTest.php
+++ b/Tests/Functional/Updates/TexticonSizeUpdateTest.php
@@ -23,6 +23,8 @@ final class TexticonSizeUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Functional/Updates/TexticonTypeUpdateTest.php
+++ b/Tests/Functional/Updates/TexticonTypeUpdateTest.php
@@ -23,6 +23,8 @@ final class TexticonTypeUpdateTest extends FunctionalTestCase
     protected array $coreExtensionsToLoad = [
         'seo',
         'rte_ckeditor',
+        'extensionmanager',
+        'install',
     ];
 
     protected array $testExtensionsToLoad = [

--- a/Tests/Packages/demo_package/composer.json
+++ b/Tests/Packages/demo_package/composer.json
@@ -15,7 +15,11 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "demo_package"
+            "extension-key": "demo_package",
+            "version": "1.0.0",
+            "Package": {
+                "providesPackages": {}
+            }
         }
     }
 }

--- a/Tests/Unit/PackageManifestTest.php
+++ b/Tests/Unit/PackageManifestTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Unit;
+
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * From TYPO3 v15 the package metadata is read from composer.json only, so
+ * "extra.typo3/cms.version" has to stay in step with the version in
+ * ext_emconf.php. The release tooling writes the latter but not the former,
+ * which is what this test guards.
+ */
+class PackageManifestTest extends UnitTestCase
+{
+    public function testComposerManifestVersionMatchesExtEmConfVersion(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        $composerManifest = json_decode((string)file_get_contents($root . '/composer.json'), true, 512, JSON_THROW_ON_ERROR);
+        $composerVersion = $composerManifest['extra']['typo3/cms']['version'] ?? null;
+
+        self::assertNotNull($composerVersion, 'composer.json must declare extra.typo3/cms.version');
+        self::assertSame($this->readExtEmConfVersion($root . '/ext_emconf.php'), $composerVersion);
+    }
+
+    public function testComposerManifestDeclaresProvidedPackages(): void
+    {
+        $root = dirname(__DIR__, 2);
+
+        $composerManifest = json_decode((string)file_get_contents($root . '/composer.json'), true, 512, JSON_THROW_ON_ERROR);
+        $providesPackages = $composerManifest['extra']['typo3/cms']['Package']['providesPackages'] ?? null;
+
+        self::assertIsArray($providesPackages, 'composer.json must declare extra.typo3/cms.Package.providesPackages');
+
+        foreach ($providesPackages as $packageName => $relativePath) {
+            self::assertArrayHasKey(
+                $packageName,
+                $composerManifest['require'],
+                sprintf('Provided package "%s" is not required in composer.json', $packageName)
+            );
+            self::assertDirectoryExists($root . '/' . $relativePath);
+        }
+    }
+
+    /**
+     * ext_emconf.php declares its data by assigning $EM_CONF[$_EXTKEY], the way
+     * the package manager reads it, so it has to be executed rather than parsed.
+     */
+    private function readExtEmConfVersion(string $file): mixed
+    {
+        $definedVariables = (static function (string $file, string $extensionKey): array {
+            $_EXTKEY = $extensionKey;
+            require $file;
+
+            return get_defined_vars();
+        })($file, 'bootstrap_package');
+
+        return $definedVariables['EM_CONF']['bootstrap_package']['version'] ?? null;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "require-dev": {
         "b13/container": "^3.1 || dev-master",
         "bk2k/demo-package": "@dev",
-        "bk2k/extension-helper": "^2.1",
+        "bk2k/extension-helper": "^2.2",
         "friendsofphp/php-cs-fixer": "^3.90",
         "overtrue/phplint": "^9.6",
         "phpstan/phpstan": "^2.1",
@@ -79,7 +79,13 @@
         },
         "typo3/cms": {
             "extension-key": "bootstrap_package",
-            "web-dir": ".build/public"
+            "web-dir": ".build/public",
+            "version": "16.0.0",
+            "Package": {
+                "providesPackages": {
+                    "scssphp/scssphp": "Contrib/scssphp"
+                }
+            }
         }
     },
     "autoload": {


### PR DESCRIPTION
Declares the package metadata TYPO3 v15 requires in `composer.json`, for this
extension and for the `demo_package` test fixture.

```json
"typo3/cms": {
    "extension-key": "bootstrap_package",
    "web-dir": ".build/public",
    "version": "16.0.0",
    "Package": {
        "providesPackages": {
            "scssphp/scssphp": "Contrib/scssphp"
        }
    }
}
```

### Why

From TYPO3 v15 the package manifest is read from `composer.json` alone.
`PackageManager::getComposerManifest()` throws `InvalidPackageManifestException`
(`1780502553`) for any extension that declares neither a version nor
`providesPackages` — classic mode installations, where `ext_emconf.php` used to
supply both. TYPO3 v14.2 already raises a deprecation for the missing fields
([Deprecation #108345](https://docs.typo3.org/permalink/changelog:deprecation-108345-1774126701));
it fires today in the functional suite (`PackageManager.php:948`).

`providesPackages` names the Composer packages the extension ships itself so
classic mode does not look for them in a vendor directory. That is
`scssphp/scssphp`, bundled under `Contrib/scssphp` (1.13.0) — the one entry in
`require` that is not a TYPO3 extension.

`ext_emconf.php` stays: Tailor and the TER read it.

### The dependency list moves with it

Declaring the two fields also stops TYPO3 v14 from evaluating `ext_emconf.php`,
and that includes the **dependency list**. The two manifests do not agree:

| | declares |
|---|---|
| `ext_emconf.php` `constraints.depends` | `typo3`, `rte_ckeditor`, `seo` |
| `composer.json` `require` | nine `typo3/cms-*` packages |

The functional test instances therefore have to load `extensionmanager` and
`install` on top of the `seo` and `rte_ckeditor` they already loaded, otherwise
the testing framework aborts with
`Package "bootstrap_package" depends on package "extensionmanager" which does not exist.`
That is what the change to the 22 test classes is.

**Worth a separate look:** nothing in `Classes/`, `Configuration/` or
`ext_localconf.php` references `TYPO3\CMS\Extensionmanager`, so
`typo3/cms-extensionmanager` looks like a stale `require`. Removing it is a
decision about the package's public dependency declaration, so it is not part of
this PR.

### Compatibility

TYPO3 v13.4 reads neither field. `PackageManager::mapExtensionManagerConfigurationToComposerManifest()`
overwrites `version` from `ext_emconf.php` unconditionally there, so the manifest
change is a no-op on v13.4. The extra `coreExtensionsToLoad` entries are
harmless on both versions.

### Keeping the version in step

`composer set-version` did not write `extra.typo3/cms.version`, so the new field
would have drifted on the next release.
[bk2k/extension-helper#6](https://github.com/benjaminkott/extension-helper/pull/6)
fixes that and is released as 2.2.0; the constraint is raised here accordingly.
`Tests/Unit/PackageManifestTest.php` asserts the two versions match and that every
entry in `providesPackages` is required and its directory exists.

### Checks

`composer test:php:lint`, `composer cgl:ci`, `composer phpstan`,
`composer test:php:unit`, `composer test:php:functional` — all green.

Part of a set of v13-compatible preparations that can be backported to
`BP_16_0` one by one.
