### PR TITLE
[TASK] Register EXT:form configuration through auto discovery

### DIFF
--- a/Configuration/Form/BootstrapPackage/config.yaml
+++ b/Configuration/Form/BootstrapPackage/config.yaml
@@ -1,0 +1,6 @@
+name: bk2k/bootstrap-package
+label: 'Bootstrap Package'
+priority: 110
+
+imports:
+  - { resource: 'EXT:bootstrap_package/Configuration/Form/Setup.yaml' }

--- a/Tests/Functional/Form/FormYamlConfigurationTest.php
+++ b/Tests/Functional/Form/FormYamlConfigurationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Form;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Form\Mvc\Configuration\ConfigurationManagerInterface;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the EXT:form configuration this extension ships
+ *
+ * @see Configuration/Form/BootstrapPackage/config.yaml
+ */
+final class FormYamlConfigurationTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+        'form',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    #[Test]
+    public function formSetIsDiscoveredWithoutTypoScriptRegistration(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            self::markTestSkipped('Form YAML auto-discovery was introduced in TYPO3 v14.2');
+        }
+
+        // No TypoScript settings are handed over, so anything found here comes
+        // from the auto-discovered Configuration/Form/BootstrapPackage/config.yaml.
+        $configuration = $this->get(ConfigurationManagerInterface::class)->getYamlConfiguration([], false);
+
+        self::assertContains(
+            'EXT:bootstrap_package/Resources/Private/Forms/',
+            $configuration['persistenceManager']['allowedExtensionPaths'] ?? []
+        );
+
+        $renderingOptions = $configuration['prototypes']['standard']['formElementsDefinition']['Form']['renderingOptions'] ?? [];
+
+        self::assertSame('version2', $renderingOptions['templateVariant'] ?? null);
+        self::assertSame(
+            'EXT:bootstrap_package/Resources/Private/Templates/Form/',
+            $renderingOptions['templateRootPaths'][20] ?? null
+        );
+        self::assertSame(
+            'EXT:bootstrap_package/Resources/Private/Partials/Form/',
+            $renderingOptions['partialRootPaths'][20] ?? null
+        );
+        self::assertSame(
+            'EXT:bootstrap_package/Resources/Private/Layouts/Form/',
+            $renderingOptions['layoutRootPaths'][20] ?? null
+        );
+    }
+
+    #[Test]
+    public function typoScriptRegistrationIsNotAddedOnSupportingVersions(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            self::markTestSkipped('TYPO3 v13.4 has no auto-discovery and still needs the TypoScript registration');
+        }
+
+        self::assertStringNotContainsString(
+            'yamlConfigurations',
+            (string)($GLOBALS['TYPO3_CONF_VARS']['FE']['defaultTypoScript_setup'] ?? '')
+        );
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -19,7 +19,12 @@ $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 );
 
 // Register custom EXT:form configuration
-if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')) {
+// TYPO3 v14.2 and above discover Configuration/Form/BootstrapPackage/config.yaml
+// on their own, and the TypoScript registration below raises a deprecation there.
+// @deprecated Drop together with TYPO3 v13 support.
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('form')
+    && (new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 14
+) {
     \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScriptSetup(trim('
         module.tx_form {
             settings {


### PR DESCRIPTION
Registers the EXT:form configuration through the auto-discovery convention
TYPO3 v14.2 introduced, and keeps the TypoScript registration for TYPO3 v13.4
alone.

New `Configuration/Form/BootstrapPackage/config.yaml`:

```yaml
name: bk2k/bootstrap-package
label: 'Bootstrap Package'
priority: 110

imports:
  - { resource: 'EXT:bootstrap_package/Configuration/Form/Setup.yaml' }
```

The set imports the existing `Setup.yaml` rather than duplicating it, so the
resolved configuration is unchanged and `Configuration/Form/Setup.yaml` stays a
valid path for anyone who references it. Priority `110` reproduces the load
order the TypoScript key of the same number gave: the core base set is
priority 10.

### Why

`plugin.tx_form.settings.yamlConfigurations` and its `module.` counterpart are
deprecated since TYPO3 v14.2 and are not read in v15.0
([Deprecation #109412](https://docs.typo3.org/permalink/changelog:deprecation-109412-1742000001)).
`ConfigurationManager::getYamlConfiguration()` raises an `E_USER_DEPRECATED`
whenever the setting is present (`cms-form/Classes/Mvc/Configuration/ConfigurationManager.php:71-78`),
so this fires on every request of an installation with EXT:form loaded.

### Compatibility

TYPO3 v13.4 has no auto-discovery, so `ext_localconf.php` keeps the TypoScript
registration behind a version guard and is the only place v13 support has to be
removed from later. Without the guard the same YAML would be registered twice on
v14.

`YamlSource::load()` unwraps a `TYPO3.CMS.Form` section when present and is
identical in v13.4 and v14.3, so the imported `Setup.yaml` keeps working
unchanged on both.

### Coverage

`Tests/Functional/Form/FormYamlConfigurationTest.php`:

* resolves the form configuration with **no** TypoScript settings handed over,
  so everything it asserts comes from the auto-discovered set — this proves the
  discovery, the `imports` resolution and the `TYPO3.CMS.Form` unwrap;
* asserts the TypoScript registration is absent on v14+. Reverting the guard
  makes that second test fail, which is what it is there for.

### Checks

`composer test:php:lint`, `composer cgl:ci`, `composer phpstan`,
`composer test:php:unit`, `composer test:php:functional` — all green.

Part of a set of v13-compatible preparations that can be backported to
`BP_16_0` one by one. Dropping TYPO3 v13 later removes the guarded block in
`ext_localconf.php` and nothing else.
