### PR TITLE
[TASK] Register global Fluid namespace through configuration file

### DIFF
--- a/Configuration/Fluid/Namespaces.php
+++ b/Configuration/Fluid/Namespaces.php
@@ -1,0 +1,14 @@
+<?php
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+return [
+    'bk2k' => [
+        'BK2K\\BootstrapPackage\\ViewHelpers',
+    ],
+];

--- a/Tests/Functional/Fluid/GlobalNamespaceTest.php
+++ b/Tests/Functional/Fluid/GlobalNamespaceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Fluid;
+
+use BK2K\BootstrapPackage\ViewHelpers\ImplodeViewHelper;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperResolverFactoryInterface;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the global "bk2k" Fluid namespace
+ *
+ * @see Configuration/Fluid/Namespaces.php
+ */
+final class GlobalNamespaceTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    #[Test]
+    public function bk2kNamespaceIsAvailableWithoutBeingDeclaredInATemplate(): void
+    {
+        $resolver = $this->get(ViewHelperResolverFactoryInterface::class)->create();
+
+        self::assertSame(
+            ImplodeViewHelper::class,
+            $resolver->resolveViewHelperClassName('bk2k', 'implode')
+        );
+    }
+
+    #[Test]
+    public function namespaceIsNotRegisteredThroughGlobalsOnSupportingVersions(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            self::markTestSkipped('TYPO3 v13.4 has no Configuration/Fluid/Namespaces.php and still needs TYPO3_CONF_VARS');
+        }
+
+        self::assertArrayNotHasKey(
+            'bk2k',
+            $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces'] ?? []
+        );
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -58,7 +58,12 @@ if (!(bool) $extensionConfiguration->get('bootstrap_package', 'disableCssProcess
 $GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']['bootstrap'] = 'EXT:bootstrap_package/Configuration/RTE/Default.yaml';
 
 // Register "bk2k" as global fluid namespace
-$GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['bk2k'][] = 'BK2K\\BootstrapPackage\\ViewHelpers';
+// TYPO3 v14.1 and above read the namespace from Configuration/Fluid/Namespaces.php
+// and stop evaluating TYPO3_CONF_VARS for it in TYPO3 v15.0.
+// @deprecated Drop together with TYPO3 v13 support.
+if ((new \TYPO3\CMS\Core\Information\Typo3Version())->getMajorVersion() < 14) {
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']['bk2k'][] = 'BK2K\\BootstrapPackage\\ViewHelpers';
+}
 
 // Register "icon" wizard
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1687516916] = [


### PR DESCRIPTION
Declares the global `bk2k` Fluid namespace in the configuration file TYPO3 v14.1
introduced, and keeps the `TYPO3_CONF_VARS` registration for TYPO3 v13.4 alone.

New `Configuration/Fluid/Namespaces.php`:

```php
return [
    'bk2k' => [
        'BK2K\\BootstrapPackage\\ViewHelpers',
    ],
];
```

### Why

`$GLOBALS['TYPO3_CONF_VARS']['SYS']['fluid']['namespaces']` is deprecated since
TYPO3 v14.1 and is no longer merged into the resolver in v15.0
([Deprecation #108524](https://docs.typo3.org/permalink/changelog:deprecation-108524-1766073657)).
`ViewHelperResolverFactory::create()` still merges it on v14 and carries the
`@deprecated remove merging with TYPO3_CONF_VARS in TYPO3 v15.0` note. There is
no runtime deprecation for it, so this is preparation rather than a fix — it
keeps the eventual v15 change to a deletion.

### Compatibility

TYPO3 v13.4 has no `fluid.namespaces` service-provider hook and does not read
the file, so the `TYPO3_CONF_VARS` registration stays behind a version guard.
Keeping both unguarded would register the namespace twice on v14, because the
two sources are merged with `array_merge_recursive()`.

### Coverage

`Tests/Functional/Fluid/GlobalNamespaceTest.php`:

* asserts `bk2k:implode` resolves without any template-level namespace
  declaration — one assertion that holds on both majors, whichever mechanism
  supplies it. Removing `Configuration/Fluid/Namespaces.php` makes it fail with
  `UnresolvableViewHelperException` on v14, which is what it is there for;
* asserts the `TYPO3_CONF_VARS` entry is absent on v14+.

### Checks

`composer test:php:lint`, `composer cgl:ci`, `composer phpstan`,
`composer test:php:unit`, `composer test:php:functional` — all green.

Part of a set of v13-compatible preparations that can be backported to
`BP_16_0` one by one. Dropping TYPO3 v13 later removes the guarded block in
`ext_localconf.php` and nothing else.
