### PR TITLE
[BUGFIX] Replace removed pagination ViewHelpers in indexed_search

### DIFF
--- a/Resources/Private/Partials/IndexedSearch/Pagination.html
+++ b/Resources/Private/Partials/IndexedSearch/Pagination.html
@@ -1,0 +1,40 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:if condition="{pagination.allPageNumbers -> f:count()} > 1">
+    <nav aria-label="{f:translate(key: 'pagination.aria.label', extensionName: 'BootstrapPackage')}">
+        <ul class="pagination">
+
+            <f:if condition="{pagination.previousPageNumber}">
+                <li class="page-item page-item-previous">
+                    <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.previous" extensionName="BootstrapPackage" /></f:variable>
+                    <a href="#" class="page-link tx-indexedsearch-page-selector" aria-label="{ariaLabel}" data-prefix="tx_indexedsearch" data-pointer="{pagination.previousPageNumber - 1}" data-free-index-uid="{freeIndexUid}"><f:translate key="pagination.previous" extensionName="BootstrapPackage" /></a>
+                </li>
+            </f:if>
+
+            <f:for each="{pagination.allPageNumbers}" as="pageNumber">
+                <f:if condition="{pageNumber} == {searchParams.pointer + 1}">
+                    <f:then>
+                        <f:variable name="ariaLabel"><f:translate key="pagination.aria.current.page" arguments="{0: pageNumber}" extensionName="BootstrapPackage" /></f:variable>
+                        <li class="page-item active">
+                            <a href="#" class="page-link tx-indexedsearch-page-selector" aria-label="{ariaLabel}" aria-current="page" data-prefix="tx_indexedsearch" data-pointer="{pageNumber - 1}" data-free-index-uid="{freeIndexUid}">{pageNumber}</a>
+                        </li>
+                    </f:then>
+                    <f:else>
+                        <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.page" arguments="{0: pageNumber}" extensionName="BootstrapPackage" /></f:variable>
+                        <li class="page-item">
+                            <a href="#" class="page-link tx-indexedsearch-page-selector" aria-label="{ariaLabel}" data-prefix="tx_indexedsearch" data-pointer="{pageNumber - 1}" data-free-index-uid="{freeIndexUid}">{pageNumber}</a>
+                        </li>
+                    </f:else>
+                </f:if>
+            </f:for>
+
+            <f:if condition="{pagination.nextPageNumber}">
+                <li class="page-item page-item-next">
+                    <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.next" extensionName="BootstrapPackage" /></f:variable>
+                    <a href="#" class="page-link tx-indexedsearch-page-selector" aria-label="{ariaLabel}" data-prefix="tx_indexedsearch" data-pointer="{pagination.nextPageNumber - 1}" data-free-index-uid="{freeIndexUid}"><f:translate key="pagination.next" extensionName="BootstrapPackage" /></a>
+                </li>
+            </f:if>
+
+        </ul>
+    </nav>
+</f:if>
+</html>

--- a/Resources/Private/Templates/IndexedSearch/Search/Search.html
+++ b/Resources/Private/Templates/IndexedSearch/Search/Search.html
@@ -1,4 +1,5 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" xmlns:is="http://typo3.org/ns/TYPO3/CMS/IndexedSearch/ViewHelpers" data-namespace-typo3-fluid="true">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:asset.script identifier="indexed_search_pagination" src="EXT:indexed_search/Resources/Public/JavaScript/pagination.js" />
 <f:alias map="{sword: searchParams.sword}">
     <f:render partial="Form" arguments="{_all}" />
 </f:alias>
@@ -27,7 +28,9 @@
         <f:if condition="{result.count} > 0">
             <f:then>
                 <p>
-                    <is:pageBrowsingResults numberOfResults="{result.count}" currentPage="{searchParams.pointer}" resultsPerPage="{searchParams.numberOfResults}" />
+                    <f:sanitize.html>
+                        <f:translate key="displayResults" arguments="{0: result.pagination.startRecordNumber, 1: result.pagination.endRecordNumber, 2: result.count}" />
+                    </f:sanitize.html>
                     {result.sectionText}
                 </p>
                 <!-- render the anchor-links to the sections inside the displayed result rows -->
@@ -64,7 +67,7 @@
                         </f:else>
                     </f:if>
                 </f:for>
-                <is:pageBrowsing numberOfResults="{result.count}" maximumNumberOfResultPages="{settings.page_links}" currentPage="{searchParams.pointer}" resultsPerPage="{searchParams.numberOfResults}" />
+                <f:render partial="Pagination" arguments="{pagination: result.pagination, searchParams: searchParams, freeIndexUid: freeIndexUid}" />
             </f:then>
             <f:else>
                 <div class="alert alert-info">


### PR DESCRIPTION
# Pull Request

## Related Issues

* Fixes #1580
* Fixes #1503
* Supersedes #1537

## Description

TYPO3 v13.0 removed `is:pageBrowsingResults` and `is:pageBrowsing`
([Breaking-102945](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.0/Breaking-102945-PaginationOfIndexedSearchReplaced.html)),
so the overridden search template raises a fatal error on every result page. Both ViewHelpers were
still in use, which means this affects every TYPO3 version this package supports.

The result counter is now built from the pagination object the controller assigns, and the pager
moves into a partial of our own instead of falling back to the one in EXT:indexed_search. Shipping
it here keeps the markup consistent with the rest of the plugin: it uses `.pagination`,
`.page-item` and `.page-link` like `Templates/ViewHelpers/Paginate/Index.html`, and it carries the
aria labels the core partial has no equivalent for.

Two things worth calling out:

* The page links stay **text-only anchors**. `EXT:indexed_search/Resources/Public/JavaScript/pagination.js`
  matches `event.target` against the selector class directly instead of using `closest()`, so a
  nested `<span class="page-link-title">` would swallow the click and the link would do nothing.
* The template **loads that script now**. The core template does, and this one — overriding it as a
  whole — never has. Without it the pagination links are inert.

`settings.page_links` is no longer passed on, because `SearchController` reads it itself while
assembling the pagination object.

## Version compatibility

Verified against the core templates on `13.4`, `14.3` and `main`:

* `f:sanitize.html` and `result.pagination.*` exist unchanged on all three.
* `f:translate key="displayResults"` resolves everywhere — v14 rewrote the core partial to the
  `domain: 'indexed_search.messages'` syntax, but the `displayResults*` trans-units still live in
  `EXT:indexed_search/Resources/Private/Language/locallang.xlf`. Using the domain syntax here would
  break v13.4.
* Templates stay `*.html`, not `*.fluid.html`. v14 renamed the core files, but
  [Feature-108166](https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/14.0/Feature-108166-FluidFileExtensionAndTemplateResolving.html)
  keeps `.html` in the resolving chain and explicitly states the new extension is not supported for
  extensions that still support < v14.

## Steps to Validate

1. Install EXT:indexed_search, add the search plugin to a page and index enough pages to get more
   than one result page.
2. Search — the result page renders instead of throwing, and shows the "Displaying results …" line.
3. The pager below the results is Bootstrap styled, the current page is marked `active`.
4. Click a page link, including directly on the number: the form submits and the next page loads.

## Prerequisites

* [x] Changes have been tested on TYPO3 v13.4 LTS
* [x] Changes have been tested on TYPO3 v14.3
* [x] Changes have been checked for CGL compliance `php-cs-fixer fix`
* [x] No SCSS changes, no asset rebuild required
