### PR TITLE
[BUGFIX] Hand boolean site settings to the parser as booleans

### DIFF
--- a/Classes/Service/CompileService.php
+++ b/Classes/Service/CompileService.php
@@ -13,6 +13,8 @@ use BK2K\BootstrapPackage\Parser\ParserInterface;
 use BK2K\BootstrapPackage\Utility\TypoScriptUtility;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\Entity\SiteSettings;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -113,14 +115,32 @@ class CompileService
         }
 
         // Fetch settings
+        $site = $request->getAttribute('site');
+        $siteSettings = $site instanceof Site ? $site->getSettings() : null;
         $prefix = 'plugin.bootstrap_package.settings.' . $extension . '.';
         foreach ($constants as $constant => $value) {
             if (strpos($constant, $prefix) === 0) {
-                $variables[substr($constant, strlen($prefix))] = $value;
+                $variables[substr($constant, strlen($prefix))] = $this->normalizeVariable($constant, (string) $value, $siteSettings);
             }
         }
 
         return $variables;
+    }
+
+    /**
+     * Site settings are cast to string on their way into TypoScript constants,
+     * which turns a boolean `false` into an empty string. Parsers like scssphp
+     * read that as an unquoted string, which is truthy, so a disabled setting
+     * would silently be enabled. Settings declared as boolean are therefore
+     * handed over as the literals the parsers understand as booleans.
+     */
+    protected function normalizeVariable(string $constant, string $value, ?SiteSettings $siteSettings): string
+    {
+        if (!is_bool($siteSettings?->get($constant))) {
+            return $value;
+        }
+
+        return in_array(strtolower(trim($value)), ['', '0', 'false'], true) ? 'false' : 'true';
     }
 
     /**

--- a/Tests/Functional/Service/CompileServiceTest.php
+++ b/Tests/Functional/Service/CompileServiceTest.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Service;
+
+use BK2K\BootstrapPackage\Service\CompileService;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\CMS\Core\Core\Environment;
+use TYPO3\CMS\Core\EventDispatcher\NoopEventDispatcher;
+use TYPO3\CMS\Core\Http\ServerRequest;
+use TYPO3\CMS\Core\Site\Entity\Site;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\TypoScript\AST\AstBuilder;
+use TYPO3\CMS\Core\TypoScript\AST\Node\RootNode;
+use TYPO3\CMS\Core\TypoScript\FrontendTypoScript;
+use TYPO3\CMS\Core\TypoScript\Tokenizer\LossyTokenizer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for class \BK2K\BootstrapPackage\Service\CompileService
+ */
+final class CompileServiceTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+        'typo3conf/ext/demo_package',
+    ];
+
+    /**
+     * Settings declared as boolean are cast to string on their way into TypoScript
+     * constants, which leaves nothing but an empty string for a disabled setting.
+     * The parser must not read that as an enabled setting.
+     */
+    #[DataProvider('booleanSettingsReachTheParserAsBooleansDataProvider')]
+    #[Test]
+    public function booleanSettingsReachTheParserAsBooleans(bool $enableGradients, string $expectedDeclaration): void
+    {
+        $site = $this->createSiteWithSettings([
+            'plugin' => [
+                'bootstrap_package' => [
+                    'settings' => [
+                        'scss' => [
+                            'enable-gradients' => $enableGradients,
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $compiledFile = GeneralUtility::makeInstance(CompileService::class)->getCompiledFile(
+            $this->buildRequest($site),
+            'typo3conf/ext/demo_package/Resources/Public/Scss/Variables/theme.scss'
+        );
+
+        self::assertNotNull($compiledFile);
+        self::assertStringContainsString(
+            $expectedDeclaration,
+            (string) file_get_contents(Environment::getPublicPath() . '/' . $compiledFile)
+        );
+    }
+
+    public static function booleanSettingsReachTheParserAsBooleansDataProvider(): array
+    {
+        return [
+            'disabled setting' => [
+                'enableGradients' => false,
+                'expectedDeclaration' => 'gradients:disabled',
+            ],
+            'enabled setting' => [
+                'enableGradients' => true,
+                'expectedDeclaration' => 'gradients:enabled',
+            ],
+        ];
+    }
+
+    protected function createSiteWithSettings(array $settings): Site
+    {
+        $this->get(SiteWriter::class)->write('bootstrap-package-test', [
+            'rootPageId' => 1,
+            'base' => 'http://localhost/',
+            'dependencies' => [
+                'bootstrap-package/bootstrap-5',
+            ],
+            'settings' => $settings,
+        ]);
+        $this->get(CacheManager::class)->flushCaches();
+
+        return $this->get(SiteFinder::class)->getSiteByIdentifier('bootstrap-package-test');
+    }
+
+    protected function buildRequest(Site $site): ServerRequest
+    {
+        // Site settings are written into TypoScript constants as plain strings,
+        // see SysTemplateTreeBuilder::addDefaultTypoScriptConstantsFromSite().
+        $flatSettings = [];
+        foreach ($site->getSettings()->getAllFlat() as $identifier => $value) {
+            $flatSettings[$identifier] = (string) $value;
+        }
+
+        $lineStream = (new LossyTokenizer())->tokenize('plugin.tx_bootstrappackage.settings.overrideParserVariables = 1');
+        $typoScriptAst = (new AstBuilder(new NoopEventDispatcher()))->build($lineStream, new RootNode());
+
+        $typoScriptAttribute = new FrontendTypoScript(new RootNode(), [], $flatSettings, []);
+        $typoScriptAttribute->setSetupTree($typoScriptAst);
+        $typoScriptAttribute->setSetupArray($typoScriptAst->toArray());
+
+        return (new ServerRequest())
+            ->withAttribute('site', $site)
+            ->withAttribute('frontend.typoscript', $typoScriptAttribute);
+    }
+}

--- a/Tests/Packages/demo_package/Resources/Public/Scss/Variables/theme.scss
+++ b/Tests/Packages/demo_package/Resources/Public/Scss/Variables/theme.scss
@@ -1,0 +1,9 @@
+$enable-gradients: true !default;
+
+.demo {
+    @if $enable-gradients {
+        gradients: enabled;
+    } @else {
+        gradients: disabled;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Related Issues

* Backport of #1644
* Related to #1634 — same root cause (`(string) false === ''`), but in a different consumer: there a
  TypoScript condition, here the variables handed to the SCSS parser. This PR does not fix #1634.

## Description

Site settings reach TypoScript by being cast to string
([`SysTemplateTreeBuilder::addDefaultTypoScriptConstantsFromSite()`](https://github.com/TYPO3/typo3/blob/main/typo3/sysext/core/Classes/TypoScript/IncludeTree/SysTemplateTreeBuilder.php)
writes `$identifier . ' = ' . $value`), so a boolean `false` leaves nothing but an empty value while
`true` becomes `1`. The empty value survives as an empty constant — `AstBuilder` stores `''` and
`flatten()` only drops `null` — and `CompileService` passes it on to scssphp, where
`Compiler::injectVariables()` falls back to `coerceValue('')`. That is an unquoted string, and in
SCSS everything except `false` and `null` is truthy.

All four boolean SCSS settings are therefore stuck in their enabled state. Compiled against
`Resources/Public/Scss/bootstrap5/theme.scss` with the setting switched off:

| Setting | as delivered (`''`) | with a real `false` |
| --- | --- | --- |
| `enable-rounded` | 116 × `border-radius:` | 59 |
| `enable-shadows` | 83 × `box-shadow:` | 54 |
| `enable-gradients` | 5 × `gradient(` | 3 |
| `enable-transitions` | 99 × `transition:` | 31 |

`$enable-rounded`, `$enable-shadows` and `$enable-transitions` cannot be switched off at all, and
`$enable-gradients` compiles gradients into the theme although it defaults to `false` — the
definition defaults are always emitted as constants and `overrideParserVariables` defaults to `true`,
so this hits a stock installation. Before the migration to site sets the constants carried the
literals `true` and `false`, which the parser resolved correctly, so this is a regression of that
migration and not something the SCSS defaults ever guarded against.

The variables handed over to the parser are normalized now: if the setting behind a constant is
declared as boolean, its value is passed on as the literal the parser understands as a boolean.
Only the *declaration* is read from the site settings, the *value* keeps coming from the constants,
so overrides through `sys_template` constants stay effective, and installations without site
settings (plain constants, TYPO3 without sets) behave exactly as before.

Fixing it in the SCSS instead — declaring `$enable-gradients: false` without `!default` — would have
silenced the symptom, but a literal declaration overwrites the injected variable, so the setting
would stop working in the other direction, and the remaining three would stay broken.

## Version compatibility

* `Site::getSettings()` and `SiteSettings::get()` are identical on `13.4` and `14.3`/`main`.
  `getSettings()` is declared on `Site`, not on `SiteInterface`, hence the `instanceof` guard.
* The core writes the site constants the same way on both lines, so both are affected and both are
  fixed by this.

## Steps to Validate

1. Set up a site with the `bootstrap-package/full` set and leave the SCSS options at their defaults.
2. Look at the compiled CSS in `typo3temp/assets/bootstrappackage/css/`: `linear-gradient` shows up
   in the button and dropdown rules although `$enable-gradients` is `false`. With this change those
   rules are gone.
3. Switch `$enable-rounded` off in the site settings and reload: `border-radius` declarations
   disappear, which they previously did not.
4. Switch it back on: they return.

## Prerequisites

* [x] Verified against scssphp for every combination a constant can arrive in: bool `false` (`''`),
      bool `true` (`'1'`), a `sys_template` override to `false`, and legacy string constants without
      site settings
* [ ] Functional test **not** executed locally — the DDEV web container does not come up here
      (`supervisord`: another program listening on a configured port), so CI has to confirm it
* [ ] `php-cs-fixer` not run locally for the same reason (no `.build` in this checkout)
* [x] No SCSS changes shipped — the only `.scss` file added is a test fixture, no asset rebuild
      required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Df5132tmgofeurAwSRsL9
