### PR TITLE
[TASK] Modernize the GitHub Actions workflows and the deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,10 @@ jobs:
           tools: composer:v2
       - name: Download Deployer
         run: |
-          curl -LO https://deployer.org/deployer.phar;
-          sudo mv deployer.phar /usr/local/bin/dep;
-          sudo chmod +x /usr/local/bin/dep;
-          dep self-update;
+          curl -fLO https://github.com/deployphp/deployer/releases/download/v8.0.5/deployer.phar
+          sudo mv deployer.phar /usr/local/bin/dep
+          sudo chmod +x /usr/local/bin/dep
+          dep --version
       - name: Setup SSH Key
         env:
           SSH_AUTH_SOCK: /tmp/ssh-auth.sock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - id: setup_php
         name: Set up PHP ${{ matrix.php }}
         uses: shivammathur/setup-php@v2
@@ -47,7 +47,7 @@ jobs:
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "timestamp=$(date +"%s")" >> $GITHUB_OUTPUT
       - name: Cache Composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ${{ steps.composer-cache-vars.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ matrix.php }}-${{ matrix.typo3 }}-${{ steps.composer-cache-vars.outputs.timestamp }}
@@ -96,9 +96,9 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: 24
       - name: Install
@@ -124,7 +124,7 @@ jobs:
     if: (github.ref == 'refs/heads/master') && github.event_name != 'pull_request' && (github.repository == 'benjaminkott/bootstrap_package')
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up PHP Version 7.4
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,10 +125,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Set up PHP Version 7.4
+      - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.4
           tools: composer:v2
       - name: Download Deployer
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.4
           extensions: intl, mbstring, json, zip, curl
 
       - name: Install tailor

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 

--- a/Build/deploy.php
+++ b/Build/deploy.php
@@ -11,28 +11,26 @@ namespace Deployer;
 
 require 'recipe/common.php';
 
-// TYPO3
-desc('Prepare Bootstrap Package');
+desc('Move the repository into the extension folder of the document root');
 task('typo3:prepare', function () {
-    run('rm -rf {{release_path}}/../tmp');
-    run('mkdir -p {{release_path}}/../tmp/extensions/bootstrap_package');
-    run('mv {{release_path}}/{,.[^.]}* {{release_path}}/../tmp/extensions/bootstrap_package');
-    run('mkdir -p {{release_path}}/extensions');
-    run('mv {{release_path}}/../tmp/extensions {{release_path}}');
-    run('rm -rf {{release_path}}/../tmp');
-});
-desc('Finish TYPO3 Deployment');
-task('typo3:finish', function () {
-    run('cd {{release_path}} && {{bin/php}} ./bin/typo3 extension:setup');
-    run('cd {{release_path}} && {{bin/php}} ./bin/typo3 cache:flush');
-    run('cd {{release_path}} && {{bin/php}} ./bin/typo3 cache:warmup');
-    run('cd {{release_path}} && {{bin/php}} ./bin/typo3 upgrade:run');
+    cd('{{release_path}}');
+    run('mkdir -p extensions/bootstrap_package');
+    run('find . -mindepth 1 -maxdepth 1 -name extensions -prune -o -exec mv -t extensions/bootstrap_package {} +');
 });
 
-// Main
+desc('Finish TYPO3 Deployment');
+task('typo3:finish', function () {
+    cd('{{release_path}}');
+    run('{{bin/php}} ./bin/typo3 extension:setup');
+    run('{{bin/php}} ./bin/typo3 cache:flush');
+    run('{{bin/php}} ./bin/typo3 cache:warmup');
+    run('{{bin/php}} ./bin/typo3 upgrade:run');
+});
+
+desc('Deploy your project');
 task('deploy', [
     'deploy:info',
-    'deploy:prepare',
+    'deploy:setup',
     'deploy:lock',
     'deploy:release',
     'deploy:update_code',
@@ -42,14 +40,18 @@ task('deploy', [
     'deploy:symlink',
     'typo3:finish',
     'deploy:unlock',
-    'cleanup',
-])->desc('Deploy your project');
-after('deploy', 'success');
+    'deploy:cleanup',
+    'deploy:success',
+]);
 
 // If deploy fails automatically unlock.
 after('deploy:failed', 'deploy:unlock');
 
-// Shared Directories and Files
+// Deploy the branch that is checked out, not the default branch of the remote.
+set('branch', function () {
+    return runLocally('git rev-parse --abbrev-ref HEAD');
+});
+
 set('shared_dirs', [
     'config',
     'web/fileadmin',
@@ -63,8 +65,6 @@ set('shared_files', [
     'web/typo3conf/LocalConfiguration.php',
     'web/typo3conf/PackageStates.php',
 ]);
-
-// Set Writeable files
 set('writable_dirs', [
     'config',
     'web/fileadmin',
@@ -73,18 +73,13 @@ set('writable_dirs', [
     'web/uploads',
 ]);
 
-// Misc
-set('allow_anonymous_stats', false);
-
-// Hosts
 host(getenv('SSH_HOST'))
-    ->set('repository', 'https://github.com/benjaminkott/bootstrap_package')
-    ->user(getenv('SSH_USER'))
-    ->port('22')
-    ->set('keep_releases', '2')
-    ->set('bin/php', 'php')
-    ->set('deploy_path', '~/html/{{application}}')
+    ->setRemoteUser(getenv('SSH_USER'))
+    ->setPort(22)
+    ->setDeployPath('~/html/{{application}}')
     ->set('application', 'bootstrappackage')
-    ->set('ssh_type', 'native')
-    ->set('http_user', getenv('SSH_USER'))
-    ->set('bin/composer', 'composer');
+    ->set('repository', 'https://github.com/benjaminkott/bootstrap_package')
+    ->set('keep_releases', 2)
+    ->set('bin/php', 'php')
+    ->set('bin/composer', 'composer')
+    ->set('http_user', getenv('SSH_USER'));


### PR DESCRIPTION
## Description

Backport of #1646 to `BP_16_0`. The branch carried the same workflows
and `Build/deploy.php`, so this is the identical diff.

**Actions**

| Action | before | now |
| --- | --- | --- |
| `actions/checkout` | v6 | v7 |
| `actions/cache` | v5 | v6 |
| `actions/setup-node` | v6 | v7 |
| `shivammathur/setup-php` | v2 | v2 (moving tag, already current) |

All three majors are ESM and dependency migrations with no change
relevant to these workflows. The only behavioural change is
`actions/checkout@v7` refusing to check out a fork pull request under
`pull_request_target` and `workflow_run` — neither trigger is used
here.

**PHP in the tooling jobs**

`deployment` in `ci.yml` and `publish` in `publish.yml` were pinned to
PHP 7.4, out of support since November 2022. Both run on 8.4 now.
Neither executes extension code — they run Deployer and tailor on the
runner — so this is independent of the matrix in `build-php`.

`typo3/tailor` 2.0.0 requires `^8.2`. On 7.4 composer silently resolved
back to tailor 1.7.0, so the release publish was running a client two
majors old.

**Deployer 6.9 → 8.0.5**

`https://deployer.org/deployer.phar` serves 6.8.0 and its `self-update`
is major locked (`PharUpdateCommand`), so the deployment has been
running Deployer 6.9.0 from 2021 — not the 8.0.5 the URL suggests. The
download is pinned to a GitHub release now, so the deploying version is
the one written in the workflow. Deployer 8.0.5 requires PHP `^8.3`,
which the bump above provides.

`Build/deploy.php` is ported to the version 7 API:

* Recipe tasks renamed: `deploy:prepare` → `deploy:setup`, `cleanup` →
  `deploy:cleanup`, `success` → `deploy:success`. The explicit task
  list is kept — the default `deploy` of 7 and later does not include
  `deploy:vendors`, and `typo3:prepare` has to sit between
  `deploy:update_code` and `deploy:shared`.
* Host setters: `->user()` → `->setRemoteUser()`, `->port()` →
  `->setPort()`, `->set('deploy_path')` → `->setDeployPath()`.
  `ssh_type` and `allow_anonymous_stats` are gone with the single
  native SSH client of 7.
* `deploy:update_code` now fetches a `git archive` instead of cloning.
  A release no longer carries `.git`, and it honours the
  `export-ignore` rules in `.gitattributes` — `Build/`, `Tests/` and
  `.github/` stop being deployed, which is what the package artifact
  contains anyway.
* That leaves no dotfile at the release root, and the brace expansion
  in `typo3:prepare` (`mv {{release_path}}/{,.[^.]}*`) needs one or
  `mv` fails. It collects the release with `find` instead, which
  handles both cases.
* `branch` is resolved from the checkout the way Deployer 6 did; the
  default of 7 and later is the default branch of the remote, which
  would ignore what the workflow checked out.
* `typo3:prepare` and `typo3:finish` use `cd()` instead of prefixing
  every command with `cd … &&`.

Verified locally against `Build/deploy.php` on the 8.0.5 phar: the
`deploy` task tree resolves to the intended thirteen steps, the host
block loads, and `php-cs-fixer` is clean on the file.

Merge #1646 first. The commits carry no `(cherry picked from commit …)`
trailer yet, because the squash merge on `master` has not produced its
hash — add it when rebasing this branch.

The `deployment` job is gated on `refs/heads/master`, so on this branch
only `publish` and the two build jobs ever run.

## Related issues

* Backport of #1646

## Type of change

* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## How to validate

1. Watch the `CI` run on this pull request: `Build PHP`,
   `Build Frontend` and the composer and npm caches behave as before.
2. `deployment` and `publish` do not run on a pull request. The
   deployment is exercised on the next merge to `master`; watch the
   `Deploy` step for the ported task names and check that
   `releases/<n>/extensions/bootstrap_package` came out complete.
3. `dep rollback` on the host is the way back if it does not.

## AI assistance

* Agent and version: Claude Code 2.0.76
* Model and effort/reasoning level: Claude Opus 5, default effort
* Share written by the agent: the version bumps, the Deployer recipe
  port and the commit messages
* Reviewed and understood before pushing: yes

## Checklist

* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged — checked on
      `Build/deploy.php`, the only PHP file touched
* [ ] `composer phpstan` passes — not run; `Build/` is outside its
      `paths`
* [ ] `composer test` passes — not run; no extension code touched
* [ ] A bugfix comes with a test that fails without it — appreciated,
      not required
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed
      (`npm --prefix Build ci && npm --prefix Build run build`)
* [x] Documentation updated if the change is user facing

## Left alone, worth a look

* `writable_dirs` and `http_user` are configured but `deploy:writable`
  is not in the deploy task list and never was, so they do nothing.
  Wiring it up would newly run `setfacl` against production, so it is
  not part of this.
* The `deployment` job installs `tools: composer:v2` but never uses
  it — `deploy:vendors` runs composer on the target host.
* `composer global require typo3/tailor … --no-suggest` — the flag is
  a no-op under Composer 2 and only produces a deprecation warning.
