### PR TITLE
[BUGFIX] Keep the git metadata of a deployed release

### DIFF
--- a/Build/deploy.php
+++ b/Build/deploy.php
@@ -52,6 +52,11 @@ set('branch', function () {
     return runLocally('git rev-parse --abbrev-ref HEAD');
 });
 
+// The document root requires this package as dev-master from a path repository,
+// and composer reads that version from the git metadata of the release. Archiving
+// leaves none behind, which resolves the package as dev-main.
+set('update_code_strategy', 'clone');
+
 set('shared_dirs', [
     'config',
     'web/fileadmin',


### PR DESCRIPTION
## Description

The deployment of #1646 failed at `deploy:vendors`:

```
Root composer.json requires bk2k/bootstrap-package dev-master, it is
satisfiable by bk2k/bootstrap-package[dev-master, 16.0.x-dev] from
composer repo (https://repo.packagist.org) but
bk2k/bootstrap-package[dev-main] from path repo (./extensions/*) has
higher repository priority.
```

The document root requires this package as `dev-master` from a path
repository over `./extensions/*`, and composer derives the version of a
path package from the git metadata it finds in it. Deployer 6 cloned
into the release and left that metadata behind. The `archive` strategy
that became the default in Deployer 7 does not, so composer falls back
to its default of `dev-main` — and because a path repository is
canonical, the matching `dev-master` on packagist stays masked instead
of filling the gap.

`update_code_strategy` goes back to `clone`, which is what Deployer 6
did and what composer reads. Releases carry `.git` again, and the
`export-ignore` rules of `.gitattributes` stop applying to them, so
`Build/` and `Tests/` are deployed as they were before #1646.

Reproduced outside the deployment, with a root `composer.json` requiring
`dev-master` from a path repository:

| Extension folder | composer resolves |
| --- | --- |
| without `.git` | `dev-main` → *could not be resolved* |
| with `.git` on `master` | `dev-master` → locks `dev-master 706fcb3` |

## Type of change

* [x] Bugfix
* [ ] Task
* [ ] Feature
* [ ] Documentation

## Related issues

* Fixes the deployment regression from #1646

## How to validate

1. `deployment` does not run on a pull request. On the merge to
   `master`, `deploy:vendors` has to pass and `deploy:symlink` has to
   move `current` to the new release.
2. Production was never touched by the failed run — it stopped two
   tasks before `deploy:symlink`, and `deploy:unlock` cleaned up.

## AI assistance

* Agent and version: Claude Code 2.0.76
* Model and effort/reasoning level: Claude Opus 5, default effort
* Share written by the agent: the fix and the commit message
* Reviewed and understood before pushing: yes

## Checklist

* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged — checked on
      `Build/deploy.php`, the only file touched
* [ ] `composer phpstan` passes — not run; `Build/` is outside its
      `paths`
* [ ] `composer test` passes — not run; no extension code touched
* [ ] A bugfix comes with a test that fails without it — the
      deployment recipe is not reachable from the test suite
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed
* [x] Documentation updated if the change is user facing

## Housekeeping on the host, not in this PR

Deployer 6 named releases by timestamp, Deployer 8 numbers them and
starts from `.dep/latest_release`, which did not exist — so the failed
run created `releases/1`. The next deploy takes `2` and rotates its own
releases normally, but the two timestamp folders from the Deployer 6 era
are not in `.dep/releases_log` and `deploy:cleanup` will never see them.
They can be removed by hand once a numbered release is live.
