### PR TITLE
[BUGFIX] Keep the git metadata of a deployed release

### DIFF
--- a/Build/deploy.php
+++ b/Build/deploy.php
@@ -52,6 +52,11 @@ set('branch', function () {
     return runLocally('git rev-parse --abbrev-ref HEAD');
 });
 
+// The document root requires this package as dev-master from a path repository,
+// and composer reads that version from the git metadata of the release. Archiving
+// leaves none behind, which resolves the package as dev-main.
+set('update_code_strategy', 'clone');
+
 set('shared_dirs', [
     'config',
     'web/fileadmin',


### PR DESCRIPTION
## Description

Backport of #1648 to `BP_16_0`, so `Build/deploy.php` stays identical
across the branches.

The deployment of the Deployer 8 port failed at `deploy:vendors`:

```
Root composer.json requires bk2k/bootstrap-package dev-master, it is
satisfiable by bk2k/bootstrap-package[dev-master, 16.0.x-dev] from
composer repo (https://repo.packagist.org) but
bk2k/bootstrap-package[dev-main] from path repo (./extensions/*) has
higher repository priority.
```

The document root requires this package as `dev-master` from a path
repository over `./extensions/*`, and composer derives the version of a
path package from the git metadata it finds in it. Deployer 6 cloned
into the release and left that metadata behind. The `archive` strategy
that became the default in Deployer 7 does not, so composer falls back
to its default of `dev-main` — and because a path repository is
canonical, the matching `dev-master` on packagist stays masked instead
of filling the gap.

`update_code_strategy` goes back to `clone`, which is what Deployer 6
did and what composer reads.

The `deployment` job is gated on `refs/heads/master`, so this branch
never deploys and the fix has no effect here. It is backported so that
`Build/deploy.php` does not start to diverge: a branch that carries a
different recipe turns every later cherry-pick touching the file into a
conflict to resolve by hand. Keeping the file identical keeps backports
a straight `git cherry-pick`.

Merge #1648 first. The commit carries no `(cherry picked from commit …)`
trailer yet, because the squash merge on `master` has not produced its
hash — add it when rebasing this branch.

## Type of change

* [x] Bugfix
* [ ] Task
* [ ] Feature
* [ ] Documentation

## Related issues

* Backport of #1648

## How to validate

1. `Build/deploy.php` is byte for byte the file on `master` after
   #1648.
2. Nothing on this branch executes it.

## AI assistance

* Agent and version: Claude Code 2.0.76
* Model and effort/reasoning level: Claude Opus 5, default effort
* Share written by the agent: the fix and the commit message
* Reviewed and understood before pushing: yes

## Checklist

* [ ] Targets `master` — backport, targets `BP_16_0`; `master` is #1648
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged — checked on
      `Build/deploy.php`, the only file touched
* [ ] `composer phpstan` passes — not run; `Build/` is outside its
      `paths`
* [ ] `composer test` passes — not run; no extension code touched
* [ ] A bugfix comes with a test that fails without it — the
      deployment recipe is not reachable from the test suite
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed
* [x] Documentation updated if the change is user facing
