### PR TITLE
[BUGFIX] Render table cells containing "0"

### DIFF
--- a/Resources/Private/Partials/ContentElements/Table/Columns.html
+++ b/Resources/Private/Partials/ContentElements/Table/Columns.html
@@ -43,7 +43,7 @@
     </f:else>
 </f:if>
 
-<f:if condition="{cell}">
+<f:if condition="{cell} != ''">
     <f:then>
         <f:format.nl2br>{cell}</f:format.nl2br>
     </f:then>

--- a/Tests/Functional/ContentElements/Fixtures/Table/pages.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Table/pages.csv
@@ -1,0 +1,3 @@
+"pages",,,,,
+,"uid","pid","sorting","doktype","slug","title"
+,1,0,256,1,"/","Root"

--- a/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript
+++ b/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript
@@ -1,0 +1,21 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Element/Table.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+            where = colPos = 0
+        }
+        renderObj < tt_content.table
+    }
+}

--- a/Tests/Functional/ContentElements/Fixtures/Table/tt_content.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Table/tt_content.csv
@@ -1,0 +1,3 @@
+"tt_content",,,,,,,,
+,"uid","pid","sorting","CType","colPos","header","bodytext","table_delimiter","table_enclosure"
+,1,1,256,"table",0,"","0||text",124,0

--- a/Tests/Functional/ContentElements/TableTest.php
+++ b/Tests/Functional/ContentElements/TableTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\ContentElements;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the rendered cells of the table content element
+ *
+ * @see Resources/Private/Partials/ContentElements/Table/Columns.html
+ */
+final class TableTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Table/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Table/tt_content.csv');
+
+        $this->get(SiteWriter::class)->write('bootstrap-package-test', [
+            'rootPageId' => 1,
+            'base' => 'http://localhost/',
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/ContentElements/Fixtures/Table/setup.typoscript',
+        ]);
+    }
+
+    /**
+     * The row is "0||text": a cell carrying a zero, an empty cell and a cell
+     * carrying a word. A zero is falsy, so a condition on the cell alone drops
+     * it and the empty-cell fallback takes its place.
+     */
+    #[Test]
+    public function cellCarryingAZeroIsRendered(): void
+    {
+        self::assertStringContainsString(
+            '<td>0</td>',
+            $this->renderFrontendPage(1)
+        );
+    }
+
+    #[Test]
+    public function emptyCellFallsBackToANonBreakingSpace(): void
+    {
+        self::assertStringContainsString(
+            '<td>&nbsp;</td>',
+            $this->renderFrontendPage(1)
+        );
+    }
+
+    /**
+     * The template indents every cell across several lines, which says nothing
+     * about the rendered table, so the whitespace between the tags is removed
+     * before the assertions read it.
+     */
+    private function renderFrontendPage(int $pageId): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('http://localhost/index.php?id=' . $pageId)
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)preg_replace('/\s*(<[^>]++>)\s*/', '$1', (string)$response->getBody());
+    }
+}


### PR DESCRIPTION
## Description

Backport of #1613 to `BP_16_0`. Clean cherry-pick of 5913c409, no adjustment needed — the branch carries the same `typo3/cms-core: ^13.4 || ^14.3` constraint, the same PHP floor and the same test infrastructure as `master`.

A table cell was rendered when the cell itself evaluated to true, so every value PHP reads as falsy was replaced by the empty-cell fallback. `0` is a value editors type, and it disappeared from the table. The cell is now compared against the empty string.

The partial is rendered by the `table` **and** the `csv` content element, so both are affected.

## Type of change

* [x] Bugfix
* [ ] Task
* [ ] Feature
* [ ] Documentation

## Related issues

Backport of #1613.

## How to validate

1. Create a table content element whose first row contains a `0` cell, e.g. `0||text`.
2. Before the change the cell renders as `&nbsp;`; after it, as `0`.
3. `composer test:php:functional -- --filter TableTest` — `Tests/Functional/ContentElements/TableTest.php` asserts both the zero cell and the preserved empty-cell fallback, and fails without the fix.

## AI assistance

* Agent and version: Claude Code
* Model and effort/reasoning level: Opus 5 (1M context), default effort
* Share written by the agent: the corrected condition, the functional test and its fixtures, plus this backport. The original report and first patch are @braukma's.
* Reviewed and understood before pushing: yes — each step was directed and approved by the maintainer; review, local runs and CI output are in the session.

## Checklist

* [ ] Targets `master` — this is the backport; `master` carries it as 5913c409
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes
* [x] `composer test` passes
* [x] A bugfix comes with a test that fails without it — appreciated, not required
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [ ] Assets rebuilt and committed if SCSS, JavaScript or icons changed — n/a, no asset sources touched
* [ ] Documentation updated if the change is user facing — n/a, no documented behaviour changes

The checked runs were executed against `master` before the merge (functional 61/61, unit 93/93, lint, PHPStan, php-cs-fixer) and on #1613 by CI across the full `^13.4`/`^14.3` × PHP 8.2–8.5 matrix. On this branch, CI is what covers them.
