### PR TITLE
[TASK] Rebase-merge clean, separated commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,7 +36,8 @@
 ## Checklist
 
 * [ ] Targets `master`
-* [ ] Commits are signed off (`git commit -s`)
+* [ ] Commits are signed off (`git commit -s`) — appreciated, not
+      required
 * [ ] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
 * [ ] `composer cgl` leaves the code unchanged
 * [ ] `composer phpstan` passes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,20 +78,29 @@
 * A pull request is rebased onto `master`, never merged into — rebase
   again whenever `master` moved under it
 * Once it is merged, backport it: cherry-pick onto the release branches
-  it affects, one pull request per branch — check whether it applies
+  it affects, one pull request per branch — the squashed commit, or the
+  whole range where the merge was a rebase. Check whether it applies
   there, declared versions and tooling differ per branch
 * Release branches are named `BP_<major>_<minor>`
 
 ## Commits and PRs
 
-* PRs are always squash-merged into `[TYPE] Subject (#<PR number>)`,
-  e.g. `[TASK] Drop empty ext_tables.php files (#1641)`
+* A pull request whose commits are clean and separated — one concern
+  each, each of them green on its own — is rebase-merged and keeps them
+  with their authors and their subjects. Every other one is
+  squash-merged into `[TYPE] Subject (#<PR number>)`, e.g.
+  `[TASK] Drop empty ext_tables.php files (#1641)`; the squash appends
+  that number, a rebase does not, so a subject that has to carry it
+  says so itself
 * Types: `[BUGFIX]`, `[TASK]`, `[FEATURE]`; no issue number in the
   subject
 * Don't squash a PR branch yourself — the merge does it, original
   commits keep attribution
-* Every commit carries a `Signed-off-by:` trailer with the contributor's
-  name and mail from `git config` — commit with `git commit -s`
+* Every commit you write carries a `Signed-off-by:` trailer with your
+  name and mail from `git config` — commit with `git commit -s`. From an
+  outside contributor it is asked for and never a reason to reject a
+  pull request: a squash is signed by whoever merges, and a rebase
+  carries their commit as it stands
 
 ## Agent attribution
 


### PR DESCRIPTION
## Description

Squashing every pull request throws away a separation that is worth
keeping where the commits already have it: one concern each, each of them
green on its own, and an outside contributor's commit landing under their
own name. Rebase merging is already enabled on this repository, merge
commits are not — only the rule said otherwise.

The squash stays for everything else, and with it the `(#<PR number>)`
suffix, which only the squash appends. A subject that has to carry the
number under a rebase says so itself.

Sign-off follows from the same change. A squash is signed by whoever
merges it, so demanding a `Signed-off-by:` from an outside contributor was
a requirement the squash quietly satisfied. A rebase carries their commit
as it stands, and rejecting a pull request over a missing trailer is not
what this project does — the pull request template said it was required
and now reads like the test line beside it.

#1599 is the case that raised it: four commits, one concern each, the
first by an outside contributor.

## Type of change

* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## Related issues

None.

## How to validate

1. Read `AGENTS.md`, section *Commits and PRs* and the backport bullet
   under *Branches*.
2. `gh api repos/benjaminkott/bootstrap_package -q '.allow_rebase_merge'`
   — the setting the rule now matches.

## AI assistance

* Agent and version: Claude Code
* Model and effort/reasoning level: Claude Opus 5, high
* Share written by the agent: the wording of both files, from a decision
  taken by the maintainer.
* Reviewed and understood before pushing: yes, by the maintainer

## Checklist

* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [ ] `composer cgl` leaves the code unchanged — no PHP in this change
* [ ] `composer phpstan` passes — no PHP in this change
* [ ] `composer test` passes — no PHP in this change
* [ ] A bugfix comes with a test that fails without it — not a bugfix
* [ ] Holds on every TYPO3 and PHP version declared in `composer.json` —
      no code
* [ ] Assets rebuilt and committed if SCSS, JavaScript or icons changed
* [x] Documentation updated if the change is user facing —
      `Documentation/Contribution/Index.rst` says nothing about merging,
      sign-off or backporting, so there is nothing to keep in sync
