### PR TITLE
[FEATURE] Make pagination routable

### DIFF
--- a/Classes/ViewHelpers/Data/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Data/PaginateViewHelper.php
@@ -71,9 +71,12 @@ class PaginateViewHelper extends AbstractViewHelper
             ];
             ArrayUtility::mergeRecursiveWithOverrule($configuration, $this->arguments['configuration'], false);
 
-            $id = $this->arguments['id'];
+            $id = (string) $this->arguments['id'];
             $itemsPerPage = (int) $configuration['itemsPerPage'];
-            $currentPage = (int) ($request->getQueryParams()['paginate'][$id]['page'] ?? 1);
+            $paginate = $request->getQueryParams()['paginate'] ?? [];
+            $currentPage = (string) ($paginate['id'] ?? '') === $id
+                ? max(1, (int) ($paginate['page'] ?? 1))
+                : 1;
 
             if ($objects instanceof QueryResultInterface) {
                 $paginator = new QueryResultPaginator($objects, $currentPage, $itemsPerPage);

--- a/Classes/ViewHelpers/Link/PaginateViewHelper.php
+++ b/Classes/ViewHelpers/Link/PaginateViewHelper.php
@@ -32,17 +32,19 @@ class PaginateViewHelper extends AbstractTagBasedViewHelper
 
         $this->registerArgument('paginationId', 'string', 'id', true);
         $this->registerArgument('paginationPage', 'int', 'page', true);
+        $this->registerArgument('section', 'string', 'section the link jumps to', false, '');
     }
 
     public function render(): string
     {
         $paginationId = (string) $this->arguments['paginationId'];
         $paginationPage = (int) $this->arguments['paginationPage'];
-        $section = isset($this->arguments['section']) ? (string)$this->arguments['section'] : '';
+        $section = (string) $this->arguments['section'];
 
         $arguments = [];
         if ($paginationPage > 1) {
-            $arguments['paginate'][$paginationId]['page'] = $paginationPage;
+            $arguments['paginate']['id'] = $paginationId;
+            $arguments['paginate']['page'] = $paginationPage;
         }
 
         $renderingContext = $this->renderingContext;
@@ -60,8 +62,11 @@ class PaginateViewHelper extends AbstractTagBasedViewHelper
                     $typolinkConfiguration = [];
                     $typolinkConfiguration['parameter'] = 'current';
                     $typolinkConfiguration['additionalParams'] = HttpUtility::buildQueryString($arguments, '&');
-                    $typolinkConfiguration['fragment'] = $section;
+                    $typolinkConfiguration['section'] = $section;
                     $typolinkConfiguration['addQueryString'] = '1';
+                    // A route enhancer turns the pagination into route arguments, which
+                    // would then be carried into every link built here.
+                    $typolinkConfiguration['addQueryString.'] = ['exclude' => 'paginate'];
 
                     /** @var ContentObjectRenderer $contentObjectRenderer */
                     $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);

--- a/Configuration/Sets/Full/config.yaml
+++ b/Configuration/Sets/Full/config.yaml
@@ -7,6 +7,7 @@ dependencies:
   - bootstrap-package/cookie-consent
   - bootstrap-package/google-font
   - bootstrap-package/google-tag-manager
+  - bootstrap-package/pagination
   - bootstrap-package/rte
   - bootstrap-package/skiplink
 optionalDependencies:

--- a/Configuration/Sets/Pagination/config.yaml
+++ b/Configuration/Sets/Pagination/config.yaml
@@ -1,0 +1,2 @@
+name: bootstrap-package/pagination
+label: 'Bootstrap Package: Pagination'

--- a/Configuration/Sets/Pagination/route-enhancers.yaml
+++ b/Configuration/Sets/Pagination/route-enhancers.yaml
@@ -1,0 +1,18 @@
+routeEnhancers:
+  BootstrapPackagePagination:
+    type: Plugin
+    namespace: 'paginate'
+    routePath: '/{id}/page-{page}'
+    static:
+      id: true
+    requirements:
+      # Identifiers the package builds out of a content element uid, e.g.
+      # "gallery-8793". Every value that matches becomes a page cache entry of
+      # its own, so widen it only as far as your own templates need.
+      id: '[a-z][a-z0-9]*-\d+'
+      page: '\d+'
+    aspects:
+      page:
+        type: StaticRangeMapper
+        start: '2'
+        end: '1000'

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -14,4 +14,5 @@ Configuration
 
    Extension/Index
    ImageRendering/Index
+   Routing/Index
    Settings/Index

--- a/Documentation/Configuration/Routing/Index.rst
+++ b/Documentation/Configuration/Routing/Index.rst
@@ -1,0 +1,100 @@
+.. include:: /Includes.rst.txt
+
+.. index:: ! Routing
+.. _routing:
+
+=======
+Routing
+=======
+
+.. _routing-pagination:
+
+Pagination
+==========
+
+Paginated content elements — the gallery is the one the package ships —
+carry the pagination in two query arguments:
+
+``paginate[id]``
+   Identifier of the pagination that is being paged. The gallery builds
+   it out of its uid, for example ``gallery-8793``.
+
+``paginate[page]``
+   Page number. It is absent on the first page.
+
+One pagination is addressed at a time. Every other paginated element on
+the page stays on its first page, which is also all a speaking URL can
+express.
+
+Every pagination link ends in the anchor of the element it pages, so a
+new page starts at that element instead of at the top of the document.
+
+The site set ``bootstrap-package/pagination`` is part of the Full
+Package and rewrites both arguments into the path:
+
+.. code-block:: none
+
+   /gallery/tag-3/gallery-8793/page-2
+
+Without it the arguments stay in the query string and drag a cache hash
+along:
+
+.. code-block:: none
+
+   /gallery/tag-3?paginate%5Bid%5D=gallery-8793&paginate%5Bpage%5D=2&cHash=61450d52
+
+.. note::
+
+   Route enhancers travel with a site set as of TYPO3 v14.1. On TYPO3
+   v13.4 the set is loaded but its enhancer is not, and the definition
+   below has to be written into the site configuration by hand.
+
+The enhancer
+------------
+
+.. code-block:: yaml
+   :caption: EXT:bootstrap_package/Configuration/Sets/Pagination/route-enhancers.yaml
+
+   routeEnhancers:
+     BootstrapPackagePagination:
+       type: Plugin
+       namespace: 'paginate'
+       routePath: '/{id}/page-{page}'
+       static:
+         id: true
+       requirements:
+         id: '[a-z][a-z0-9]*-\d+'
+         page: '\d+'
+       aspects:
+         page:
+           type: StaticRangeMapper
+           start: '2'
+           end: '1000'
+
+Adjusting the enhancer
+----------------------
+
+A site configuration takes precedence over the sets it depends on, so
+only the keys that should differ have to be written into the site's own
+``routeEnhancers``. Templates of your own that call
+``bk2k:data.paginate`` with an identifier of another shape need the
+requirement widened:
+
+.. code-block:: yaml
+   :caption: config/sites/<identifier>/config.yaml
+
+   routeEnhancers:
+     BootstrapPackagePagination:
+       requirements:
+         id: '[a-z0-9_-]+'
+
+Keep that pattern as narrow as the identifiers in use. Every value it
+matches is a page of its own and gets its own cache entry.
+
+Two properties carry the clean URL and are worth keeping when the
+enhancer is adjusted: ``static`` on the identifier and the
+``StaticRangeMapper`` on the page number. An argument that has neither
+stays dynamic, and a cache hash returns to the URL.
+
+The range decides how many pages are reachable through the path. Beyond
+its end the pagination falls back to the query string.

--- a/Documentation/Configuration/Settings/Index.rst
+++ b/Documentation/Configuration/Settings/Index.rst
@@ -27,6 +27,7 @@ Bootstrap Package provides the following Site Sets:
 * Bootstrap Package: Cookie Consent - Cookie consent banner integration
 * Bootstrap Package: Google Font - Google Fonts integration
 * Bootstrap Package: Google Tag Manager - Google Tag Manager integration
+* Bootstrap Package: Pagination - Speaking URLs for paginated elements
 * Bootstrap Package: RTE - Rich Text Editor configuration
 * Bootstrap Package: Skiplink - Accessibility skip links
 

--- a/Resources/Private/Templates/ViewHelpers/Paginate/Index.html
+++ b/Resources/Private/Templates/ViewHelpers/Paginate/Index.html
@@ -5,7 +5,7 @@
             <f:if condition="{pagination.previousPageNumber}">
                 <li class="page-item page-item-previous">
                     <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.previous" extensionName="BootstrapPackage" /></f:variable>
-                    <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pagination.previousPageNumber}">
+                    <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pagination.previousPageNumber}" section="{configuration.section}">
                         <span class="page-link-title"><f:translate key="pagination.previous" extensionName="BootstrapPackage" /></span>
                     </bk2k:link.paginate>
                 </li>
@@ -16,7 +16,7 @@
                     <f:then>
                         <f:variable name="ariaLabel"><f:translate key="pagination.aria.current.page" arguments="{0: pageNumber}" extensionName="BootstrapPackage" /></f:variable>
                         <li class="page-item active">
-                            <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel, aria-current: 'true'}" paginationId="{id}" paginationPage="{pageNumber}">
+                            <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel, aria-current: 'true'}" paginationId="{id}" paginationPage="{pageNumber}" section="{configuration.section}">
                                 <span class="page-link-title">{pageNumber}</span>
                             </bk2k:link.paginate>
                         </li>
@@ -24,7 +24,7 @@
                     <f:else>
                         <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.page" arguments="{0: pageNumber}" extensionName="BootstrapPackage" /></f:variable>
                         <li class="page-item">
-                            <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pageNumber}">
+                            <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pageNumber}" section="{configuration.section}">
                                 <span class="page-link-title">{pageNumber}</span>
                             </bk2k:link.paginate>
                         </li>
@@ -35,7 +35,7 @@
             <f:if condition="{pagination.nextPageNumber}">
                 <li class="page-item page-item-next">
                     <f:variable name="ariaLabel"><f:translate key="pagination.aria.goto.next" extensionName="BootstrapPackage" /></f:variable>
-                    <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pagination.nextPageNumber}">
+                    <bk2k:link.paginate class="page-link" additionalAttributes="{aria-label: ariaLabel}" paginationId="{id}" paginationPage="{pagination.nextPageNumber}" section="{configuration.section}">
                         <span class="page-link-title"><f:translate key="pagination.next" extensionName="BootstrapPackage" /></span>
                     </bk2k:link.paginate>
                 </li>

--- a/Tests/Functional/ContentElements/Fixtures/Gallery/pages.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Gallery/pages.csv
@@ -1,0 +1,3 @@
+"pages",,,,,
+,"uid","pid","sorting","doktype","slug","title"
+,1,0,256,1,"/","Gallery"

--- a/Tests/Functional/ContentElements/Fixtures/Gallery/setup.typoscript
+++ b/Tests/Functional/ContentElements/Fixtures/Gallery/setup.typoscript
@@ -1,0 +1,21 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Element/Gallery.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+            where = colPos = 0
+        }
+        renderObj < tt_content.gallery
+    }
+}

--- a/Tests/Functional/ContentElements/Fixtures/Gallery/tt_content.csv
+++ b/Tests/Functional/ContentElements/Fixtures/Gallery/tt_content.csv
@@ -1,0 +1,3 @@
+"tt_content",,,,,,,
+,"uid","pid","sorting","CType","colPos","image","imagecols","items_per_page"
+,1,1,256,"gallery",0,4,4,2

--- a/Tests/Functional/ContentElements/GalleryTest.php
+++ b/Tests/Functional/ContentElements/GalleryTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\ContentElements;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\CMS\Core\Resource\File;
+use TYPO3\CMS\Core\Resource\ResourceStorage;
+use TYPO3\CMS\Core\Resource\StorageRepository;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the paginated gallery content element
+ *
+ * @see Resources/Private/Templates/ContentElements/Gallery.html
+ */
+final class GalleryTest extends FunctionalTestCase
+{
+    private const BASE = 'http://localhost/';
+
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    private ResourceStorage $storage;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Gallery/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Gallery/tt_content.csv');
+
+        $storageRepository = $this->get(StorageRepository::class);
+        GeneralUtility::mkdir_deep($this->instancePath . '/fileadmin/');
+        $this->storage = $storageRepository->findByUid(
+            $storageRepository->createLocalStorage('fixture', 'fileadmin/', 'relative', '', true)
+        );
+
+        foreach (range(1, 4) as $number) {
+            $this->attachToContentElement($this->createFile('gallery-image-' . $number . '.png'), 1, $number);
+        }
+
+        $this->get(SiteWriter::class)->write('bootstrap-package-gallery', [
+            'rootPageId' => 1,
+            'base' => self::BASE,
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/ContentElements/Fixtures/Gallery/setup.typoscript',
+        ]);
+    }
+
+    #[Test]
+    public function theGalleryShowsAsManyImagesAsItemsPerPageAllows(): void
+    {
+        $markup = $this->renderPage('/');
+
+        self::assertStringContainsString('gallery-image-1', $markup);
+        self::assertStringContainsString('gallery-image-2', $markup);
+        self::assertStringNotContainsString('gallery-image-3', $markup);
+    }
+
+    /**
+     * The gallery hands its uid to the pagination as an identifier and as the
+     * anchor of its own content element, so paging leads to the next images
+     * instead of to the top of the page.
+     */
+    #[Test]
+    public function pagingTheGalleryLeadsToTheRemainingImages(): void
+    {
+        $link = $this->pageLink($this->renderPage('/'), '2');
+        self::assertStringEndsWith('#c1', $link);
+        self::assertStringContainsString('paginate[id]=gallery-1', urldecode($link));
+
+        $markup = $this->renderPage($link);
+
+        self::assertStringContainsString('gallery-image-3', $markup);
+        self::assertStringContainsString('gallery-image-4', $markup);
+        self::assertStringNotContainsString('gallery-image-1', $markup);
+    }
+
+    private function renderPage(string $url): string
+    {
+        $response = $this->executeFrontendSubRequest(new InternalRequest(self::BASE . ltrim($url, '/')));
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    /**
+     * Target of the link labelled with the given page number.
+     */
+    private function pageLink(string $markup, string $label): string
+    {
+        $pattern = '~<a\b[^>]*href="([^"]*)"[^>]*>\s*<span class="page-link-title">' . preg_quote($label, '~') . '</span>~';
+        self::assertSame(1, preg_match($pattern, $markup, $matches), 'The gallery has no link to page ' . $label . '.');
+
+        return html_entity_decode($matches[1]);
+    }
+
+    private function createFile(string $name): File
+    {
+        file_put_contents($this->instancePath . '/fileadmin/' . $name, (string)base64_decode(self::PNG_PIXEL, true));
+        $file = $this->storage->getFile('/' . $name);
+        self::assertInstanceOf(File::class, $file);
+
+        return $file;
+    }
+
+    private function attachToContentElement(File $file, int $contentElementId, int $sorting): void
+    {
+        $this->getConnectionPool()->getConnectionForTable('sys_file_reference')->insert(
+            'sys_file_reference',
+            [
+                'pid' => 1,
+                'uid_local' => $file->getUid(),
+                'uid_foreign' => $contentElementId,
+                'tablenames' => 'tt_content',
+                'fieldname' => 'image',
+                'sorting_foreign' => $sorting,
+            ]
+        );
+    }
+
+    /**
+     * The gallery filters its files by extension, and the image only has to be
+     * readable enough for the indexer to take its dimensions off it.
+     */
+    private const PNG_PIXEL = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+}

--- a/Tests/Functional/Fluid/Fixtures/Pagination/Template.html
+++ b/Tests/Functional/Fluid/Fixtures/Pagination/Template.html
@@ -1,0 +1,14 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<f:variable name="first" value="{0: 'one', 1: 'two', 2: 'three', 3: 'four'}" />
+<f:variable name="second" value="{0: 'alpha', 1: 'beta', 2: 'gamma', 3: 'delta'}" />
+<div id="c1">
+    <bk2k:data.paginate id="gallery-1" objects="{first}" configuration="{itemsPerPage: 2, section: 'c1'}">
+        <f:for each="{paginator.paginatedItems}" as="item"><p>{item}</p></f:for>
+    </bk2k:data.paginate>
+</div>
+<div id="c2">
+    <bk2k:data.paginate id="gallery-2" objects="{second}" configuration="{itemsPerPage: 2, section: 'c2'}">
+        <f:for each="{paginator.paginatedItems}" as="item"><p>{item}</p></f:for>
+    </bk2k:data.paginate>
+</div>
+</html>

--- a/Tests/Functional/Fluid/Fixtures/Pagination/pages.csv
+++ b/Tests/Functional/Fluid/Fixtures/Pagination/pages.csv
@@ -1,0 +1,3 @@
+"pages",,,,,
+,"uid","pid","sorting","doktype","slug","title"
+,1,0,256,1,"/","Pagination"

--- a/Tests/Functional/Fluid/Fixtures/Pagination/setup.typoscript
+++ b/Tests/Functional/Fluid/Fixtures/Pagination/setup.typoscript
@@ -1,0 +1,13 @@
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = FLUIDTEMPLATE
+    10 {
+        file = EXT:bootstrap_package/Tests/Functional/Fluid/Fixtures/Pagination/Template.html
+    }
+}

--- a/Tests/Functional/Fluid/PaginationTest.php
+++ b/Tests/Functional/Fluid/PaginationTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Fluid;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for the pagination view helpers
+ *
+ * @see Classes/ViewHelpers/Data/PaginateViewHelper.php
+ * @see Classes/ViewHelpers/Link/PaginateViewHelper.php
+ */
+final class PaginationTest extends FunctionalTestCase
+{
+    private const BASE = 'http://localhost/';
+
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    /**
+     * Pagination arguments are handed over by hand here, and a missing cHash
+     * must render the page uncached instead of answering with a 404.
+     */
+    protected array $configurationToUseInTestInstance = [
+        'FE' => [
+            'pageNotFoundOnCHashError' => false,
+        ],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/Pagination/pages.csv');
+
+        $this->writeSite();
+
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/Fluid/Fixtures/Pagination/setup.typoscript',
+        ]);
+    }
+
+    #[Test]
+    public function paginationLinksCarryTheIdentifierAsAQueryValue(): void
+    {
+        $link = $this->pageLink($this->renderPage('/'), 'c1', '2');
+
+        self::assertStringContainsString('paginate[id]=gallery-1', urldecode($link));
+        self::assertStringContainsString('paginate[page]=2', urldecode($link));
+    }
+
+    /**
+     * The identifier travels as a value, so a single pagination is addressed at
+     * a time — every other one on the page stays on its first page.
+     */
+    #[Test]
+    public function onlyTheAddressedPaginationLeavesItsFirstPage(): void
+    {
+        $markup = $this->renderPage($this->pageLink($this->renderPage('/'), 'c2', '2'));
+
+        self::assertStringContainsString('<p>gamma</p>', $this->block($markup, 'c2'));
+        self::assertStringContainsString('<p>one</p>', $this->block($markup, 'c1'));
+    }
+
+    /**
+     * Nothing but the link view helper writes the pagination arguments, so the
+     * way back to the first page is a link to the page itself.
+     */
+    #[Test]
+    public function theFirstPageIsLinkedWithoutPaginationArguments(): void
+    {
+        $secondPage = $this->renderPage($this->pageLink($this->renderPage('/'), 'c2', '2'));
+        $link = $this->pageLink($secondPage, 'c2', '1');
+
+        self::assertStringNotContainsString('paginate', $link);
+        self::assertStringStartsWith('/', $link);
+    }
+
+    /**
+     * Every pagination link jumps to the top of the element it pages, so the
+     * new page starts where the reader is looking.
+     */
+    #[Test]
+    public function paginationLinksJumpToTheElementTheyPage(): void
+    {
+        $link = $this->pageLink($this->renderPage('/'), 'c2', '2');
+
+        self::assertStringEndsWith('#c2', $link);
+    }
+
+    /**
+     * The page number arrives as a query argument and the paginator refuses
+     * anything below one.
+     */
+    #[Test]
+    public function pageNumbersBelowOneFallBackToTheFirstPage(): void
+    {
+        $markup = $this->renderPage('/?paginate%5Bid%5D=gallery-1&paginate%5Bpage%5D=0');
+
+        self::assertStringContainsString('<p>one</p>', $this->block($markup, 'c1'));
+    }
+
+    /**
+     * The identifier is a value, so the shipped enhancer addresses every
+     * pagination on the site without knowing any uid.
+     */
+    #[Test]
+    public function theShippedSetRewritesPaginationLinks(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            self::markTestSkipped('Route enhancers in site sets need TYPO3 v14.1');
+        }
+        $this->writeSite(['bootstrap-package/pagination']);
+
+        $link = $this->pageLink($this->renderPage('/'), 'c2', '2');
+        self::assertSame('/gallery-2/page-2#c2', $link);
+
+        $markup = $this->renderPage($link);
+        self::assertStringContainsString('<p>delta</p>', $this->block($markup, 'c2'));
+        self::assertStringContainsString('<p>one</p>', $this->block($markup, 'c1'));
+        self::assertSame('/#c2', $this->pageLink($markup, 'c2', '1'));
+    }
+
+    private function writeSite(array $dependencies = []): void
+    {
+        $this->get(SiteWriter::class)->write('bootstrap-package-pagination', [
+            'rootPageId' => 1,
+            'base' => self::BASE,
+            'dependencies' => $dependencies,
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+    }
+
+    private function renderPage(string $url): string
+    {
+        $response = $this->executeFrontendSubRequest(new InternalRequest(self::BASE . ltrim($url, '/')));
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+
+    /**
+     * Markup of the paginated element, up to the closing tag of the wrapping
+     * div in the fixture template.
+     */
+    private function block(string $markup, string $element): string
+    {
+        $start = strpos($markup, '<div id="' . $element . '">');
+        self::assertIsInt($start, 'Element "' . $element . '" is not part of the rendered page.');
+        $end = strpos($markup, '</div>', $start);
+        self::assertIsInt($end);
+
+        return substr($markup, $start, $end - $start);
+    }
+
+    /**
+     * Target of the link labelled with the given page number.
+     */
+    private function pageLink(string $markup, string $element, string $label): string
+    {
+        $pattern = '~<a\b[^>]*href="([^"]*)"[^>]*>\s*<span class="page-link-title">' . preg_quote($label, '~') . '</span>~';
+        self::assertSame(1, preg_match($pattern, $this->block($markup, $element), $matches), 'Element "' . $element . '" has no link to page ' . $label . '.');
+
+        return html_entity_decode($matches[1]);
+    }
+}


### PR DESCRIPTION
## Description

Backport of #1653 to `BP_16_0`. The commit cherry-picks without a conflict:
every file it touches is identical on both branches, and both declare the same
TYPO3 and PHP versions.

Pagination travelled as `paginate[<id>][page]`, which puts the identifier — the
content element uid for the gallery — into the parameter name. Route enhancers
address parameters by name, so the uid had to be known when the site
configuration was written: one enhancer entry per paginated element, and a new
one every time an editor creates a gallery. Nobody maintains that, and
pagination URLs stayed unrewritten:

```
/de/galerie-2026/tag-3?paginate%5Bgallery-8793%5D%5Bpage%5D=2&cHash=61450d52…
```

The identifier is now a value of its own, `paginate[id]` beside
`paginate[page]`, and the site set `bootstrap-package/pagination` ships the one
enhancer that rewrites both. It is part of the Full Package and needs no uid:

```
/de/galerie-2026/tag-3/gallery-8793/page-2#c8793
```

One pagination is addressed at a time; every other one on the page stays on its
first page, which is also all a speaking URL can express. Verified with two
galleries side by side: paging one leaves the other on page 1, and its links do
not drag the foreign page number along.

Three things that were in the way and are fixed with it:

* The link view helper carried the query string over with `addQueryString`.
  Once an enhancer turns the pagination into *route* arguments, that carried
  them into every link, so the way back to the first page pointed at page 2.
  It now excludes `paginate` and writes those arguments itself.
* Clicking a page number reloaded the document at its top, leaving the reader
  to scroll back to a gallery halfway down the page. The anchor was there all
  along — the gallery hands its content element id over as
  `configuration.section` — but the link view helper never registered a
  `section` argument, and wrote the one it read to the typolink key `fragment`,
  which typolink does not know. The key is `section`. The pagination template
  passes the anchor on to every link it renders. An anchor belongs to one
  content element and is built out of its uid, so the caller of
  `bk2k:data.paginate` supplies it — nothing in the package writes one.
* Page numbers below one reached the paginator unchecked, and
  `?paginate[page]=0` answered with an `InvalidArgumentException`. They now
  fall back to the first page.

Route enhancers travel with a site set as of TYPO3 v14.1 (Feature #107837). On
TYPO3 v13.4 the set is loaded but its enhancer is not, and the definition has
to be written into the site configuration by hand — the manual carries it.

The view helper arguments do not change, only the query argument the link view
helper writes and the data view helper reads. Bookmarks in the old shape show
the first page instead of erroring; no fallback for the old argument shape is
kept, this being a new major.

## Type of change

* [ ] Bugfix
* [ ] Task
* [x] Feature
* [x] Documentation

## Related issues

<!-- none -->

## How to validate

1. Add `bootstrap-package/full` to a site — or
   `bootstrap-package/pagination` on its own — and create a gallery content
   element with more images than its "items per page".
2. The pagination links read `/<page>/gallery-<uid>/page-2#c<uid>`: no
   `cHash`, no `paginate[…]` query arguments.
3. Follow one. The next images render, and the browser lands on the gallery
   rather than at the top of the document.
4. The link back to page one is the page itself, `#c<uid>`.
5. Put a second gallery on the same page. Paging one leaves the other on its
   first page, and each set of links carries its own identifier and anchor.
6. `/<page>/gallery-<uid>/page-nonsense` answers 404.

## AI assistance

* Agent and version: Claude Code 2.1.250
* Model and effort/reasoning level: Claude Opus 5 (1M context), default
  reasoning effort, no override
* Share written by the agent: all of it — view helpers, site set, templates,
  documentation, tests and the commit message — written by the agent under the
  maintainer's direction. The design came out of the maintainer's analysis of
  the problem; the corrections that shaped it (one commit, never a hardcoded
  section id, prove the gallery content element itself works) came from the
  maintainer during the session.
* Reviewed and understood before pushing: yes — the maintainer followed the
  work and the verification against a live installation in the session and
  confirmed it before this was pushed.

## Checklist

* [x] Targets `BP_16_0` — backport of #1653, which targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes
* [x] `composer test` passes — lint 223, unit 96, functional 72
* [x] A bugfix comes with a test that fails without it
* [ ] Holds on every TYPO3 and PHP version declared in `composer.json`
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed — no
      asset sources touched
* [x] Documentation updated if the change is user facing

Not ticked above: everything here ran on TYPO3 14.3.6 and PHP 8.5 only. The
route enhancer in a site set is a v14.1 feature and cannot work on TYPO3 v13.4;
`Tests/Functional/Fluid/PaginationTest::theShippedSetRewritesPaginationLinks`
skips itself below v14, the rest of the suite is version independent. CI runs
both majors across PHP 8.2–8.5.

### Verified against a live installation

A site with nothing but `dependencies: [bootstrap-package/full]` — no enhancer
in the site configuration, no `sys_template`:

```
/                        200   picture-1 picture-2
/gallery-1/page-2        200   picture-3 picture-4
/gallery-1/page-3        200   picture-5
/gallery-1/page-nonsense 404
```

and with a second gallery on the same page, `/gallery-2/page-2` renders
`photo-3 photo-4` beside `picture-1 picture-2`, with links `/gallery-1/page-2#c1`
and `/#c2`.
