### PR TITLE
[TASK] Remove doubled typoscript setup import

### DIFF
--- a/Configuration/TypoScript/Extension/setup.typoscript
+++ b/Configuration/TypoScript/Extension/setup.typoscript
@@ -8,10 +8,6 @@
     @import 'EXT:bootstrap_package/Configuration/TypoScript/Extension/IndexedSearch/setup.typoscript'
 [end]
 
-[extension.isLoaded('indexed_search') == 1]
-    @import 'EXT:bootstrap_package/Configuration/TypoScript/Extension/IndexedSearch/setup.typoscript'
-[end]
-
 [extension.isLoaded('seo') == 1]
     @import 'EXT:bootstrap_package/Configuration/TypoScript/Extension/Seo/setup.typoscript'
 [end]


### PR DESCRIPTION
## Description

Currently the EXT:bootstrap_package/Configuration/TypoScript/Extension/IndexedSearch/setup.typoscript file is included twice. This patch removes one of the includes.

## Type of change

* [x] Task