### PR TITLE
[TASK] Drop the dead null check in TypoScriptUtility

### DIFF
--- a/Classes/Utility/TypoScriptUtility.php
+++ b/Classes/Utility/TypoScriptUtility.php
@@ -61,10 +61,7 @@ class TypoScriptUtility
                     $nested = [];
                 }
             }
-            $lastPart = array_shift($parts);
-            if ($lastPart !== null) {
-                $nested[$lastPart] = $value;
-            }
+            $nested[array_shift($parts)] = $value;
         }
         return $output;
     }


### PR DESCRIPTION
## Description

`unflatten()` guards the last `array_shift()` against `null`, but that branch
cannot be taken: `explode()` never returns an empty array, and the
`while (count($parts) > 1)` loop above leaves exactly one element behind. So
`array_shift()` returns a string here, and the guard is dead code.

PHPStan reads it the same way, but only since **2.2.12**, released 31 Aug:
Classes/Utility/TypoScriptUtility.php:65
Strict comparison using !== between string and null will always evaluate to true.

`composer.lock` is not committed, so every run resolves the newest matching
version. The last push build on `master` ran on 28 Aug with an older PHPStan
and was green; the code has not changed since. This branch's own build resolved
2.2.12 — the run log shows `Locking phpstan/phpstan (2.2.12)`.
Removing the guard changes no behaviour, so no test can fail without it.
## Type of change
* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation
## Related issues
None.
## How to validate
1. `composer update` first — with an older PHPStan still in a local lock the
   finding does not appear.
2. `composer phpstan` on `master` reports the finding above. Reproduced here on
   TYPO3 13.4.34 and 14.3.6, PHP 8.5.7.
3. `composer phpstan` on this branch reports nothing.
4. `composer test` is unchanged either way — the removed branch was never
   entered, so no assertion moves.
## AI assistance
* Agent and version: Claude Code
* Model and effort/reasoning level: Claude Opus 5, extended thinking
* Share written by the agent: all of it. I directed the work and made the
  calls the agent surfaced, but I did not write the lines.
* Reviewed and understood before pushing: yes
## Checklist
* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes — this is the change that makes it pass
* [x] `composer test` passes
* [x] A bugfix comes with a test that fails without it — dead code removal, no
      behaviour changes, so nothing can fail without it
* [x] Holds on every TYPO3 and PHP version declared in `composer.json` — all
      eight matrix cells green on this branch
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed — none touched
* [x] Documentation updated if the change is user facing — not user facing