### PR TITLE
[FEATURE] Resolve image variants for Extbase plugins

### DIFF
--- a/Classes/Service/ContentElementVariantsService.php
+++ b/Classes/Service/ContentElementVariantsService.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types = 1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Service;
+
+use BK2K\BootstrapPackage\DataProcessing\ContainerContextProcessor;
+use BK2K\BootstrapPackage\Utility\ImageVariantsUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Image variants for the box a content element renders in.
+ *
+ * Layouts/ContentElements/Default.html does this in Fluid, which serves
+ * every element rendered through a template of this package. An Extbase
+ * plugin is rendered through Generic.html, which hands off to
+ * tt_content.<CType>.20 via f:cObject — a rendering context that receives
+ * data and table and nothing else, so the variants the layout calculated
+ * do not reach it. Such a plugin asks here instead.
+ */
+final readonly class ContentElementVariantsService
+{
+    public function __construct(
+        private ContainerContextProcessor $containerContextProcessor
+    ) {
+    }
+
+    /**
+     * @param array $settings lib.contentElement.settings.responsiveimages
+     */
+    public function getVariants(array $settings, ContentObjectRenderer $contentObject): array
+    {
+        $variants = ImageVariantsUtility::getImageVariants($settings['variants'] ?? null);
+        $variants = $this->applyBackendLayout($variants, $settings, $contentObject);
+
+        return $this->applyContainerContext($variants, $settings, $contentObject);
+    }
+
+    /**
+     * Narrow variants by one configuration block, for the steps an element
+     * applies on top of its box — a grid column count, an image position.
+     */
+    public function narrow(array $variants, ?array $configuration): array
+    {
+        if ($configuration === null) {
+            return $variants;
+        }
+
+        return ImageVariantsUtility::getImageVariants(
+            $variants,
+            $configuration['multiplier'] ?? null,
+            $configuration['gutters'] ?? null,
+            $configuration['corrections'] ?? null
+        );
+    }
+
+    private function applyBackendLayout(array $variants, array $settings, ContentObjectRenderer $contentObject): array
+    {
+        $backendLayout = str_replace('pagets__', '', $contentObject->getData('pagelayout'));
+        if ($backendLayout === '') {
+            // What the backendlayout TypoScript object does with ifEmpty.
+            $backendLayout = 'default';
+        }
+        $colPos = (string)($contentObject->data['colPos'] ?? 0);
+
+        return $this->narrow($variants, $settings['backendlayout'][$backendLayout][$colPos] ?? null);
+    }
+
+    private function applyContainerContext(array $variants, array $settings, ContentObjectRenderer $contentObject): array
+    {
+        $data = $contentObject->data;
+        if ((int)($data['tx_container_parent'] ?? 0) === 0) {
+            return $variants;
+        }
+
+        $containerContext = array_reverse(
+            $this->containerContextProcessor->getContainerContext(
+                $this->containerContextProcessor->getPageRecords($contentObject, (int)($data['pid'] ?? 0)),
+                $data
+            )
+        );
+
+        foreach ($containerContext as $container) {
+            // childColPos, not colPos: each level is narrowed by the column
+            // the next level sits in.
+            $column = (string)$container['childColPos'];
+            $variants = $this->narrow($variants, $settings['container'][$container['CType']][$column] ?? null);
+        }
+
+        return $variants;
+    }
+}

--- a/Documentation/Configuration/ImageRendering/Index.rst
+++ b/Documentation/Configuration/ImageRendering/Index.rst
@@ -281,6 +281,78 @@ calculation process.
 
 
 
+Resolving Variants in PHP
+=========================
+
+Everything above is applied by the content element layout, which
+serves every element rendered through a template of this package. An
+Extbase plugin registered as a content element does not go that way:
+it is rendered through ``Generic.html``, which hands off to
+``tt_content.<CType>.20`` via ``f:cObject``. That call carries
+``data`` and ``table`` and nothing else, so the variants the layout
+calculated never reach the plugin's own rendering context, and an
+image rendered there falls back to whatever width its template hard
+codes.
+
+:php:`ContentElementVariantsService` answers the same question in
+PHP. Inject it and hand it the settings together with the content
+object of the element:
+
+.. code-block:: php
+
+   use BK2K\BootstrapPackage\Service\ContentElementVariantsService;
+   use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+   final class TeaserController extends ActionController
+   {
+       public function __construct(
+           private readonly ContentElementVariantsService $service,
+       ) {
+       }
+
+       public function listAction(): ResponseInterface
+       {
+           $cObj = $this->request->getAttribute('currentContentObject');
+           if (!$cObj instanceof ContentObjectRenderer) {
+               return $this->htmlResponse();
+           }
+
+           $variants = $this->service->getVariants($settings, $cObj);
+           // ...
+       }
+   }
+
+``$settings`` is the plain array below
+``lib.contentElement.settings.responsiveimages``. Read it from the
+full TypoScript through the configuration manager and convert it with
+:php:`TypoScriptService::convertTypoScriptArrayToPlainArray()`.
+
+What comes back is narrowed the way the layout narrows it: first by
+the backend layout column the element sits in, then by every
+container wrapped around it. An element in a container inside a page
+column arrives at the width of the box it actually occupies.
+
+An element that narrows further on its own — a grid with a column
+count, a layout that puts the image beside the text — applies those
+steps with :php:`narrow()`, which takes a configuration block of the
+same shape as the ones above:
+
+.. code-block:: php
+
+   $columns = $settings['contentelements']['my_element']['columns'];
+   $variants = $this->service->narrow($variants, $columns['3'] ?? null);
+
+Passing :php:`null` returns the variants unchanged, so a step that is
+not configured needs no branch around it.
+
+.. note::
+
+   The service resolves the box, not the markup. Turning the variants
+   into a ``srcset`` and a ``sizes`` attribute, or into ``picture``
+   and ``source`` elements, stays with the template that renders the
+   image.
+
+
 Crop Variants
 =============
 

--- a/Tests/Functional/Service/ContentElementVariantsServiceTest.php
+++ b/Tests/Functional/Service/ContentElementVariantsServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Service;
+
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\TestingFramework\Core\Functional\Framework\Frontend\InternalRequest;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Testcase for \BK2K\BootstrapPackage\Service\ContentElementVariantsService
+ * against the settings this package ships.
+ *
+ * The widths are the ones the content element layout arrives at for the same
+ * element, so a plugin that asks the service is handed what a template would
+ * have been handed. They are read out of a frontend request rather than
+ * calculated here: a stub cannot say what getData('pagelayout') resolves to.
+ */
+final class ContentElementVariantsServiceTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'seo',
+        'rte_ckeditor',
+        'extensionmanager',
+        'install',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'typo3conf/ext/bootstrap_package',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContentElementVariants/pages.csv');
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/ContentElementVariants/tt_content.csv');
+
+        $this->get(SiteWriter::class)->write('bootstrap-package-test', [
+            'rootPageId' => 1,
+            'base' => 'http://localhost/',
+            'languages' => [
+                [
+                    'title' => 'English',
+                    'enabled' => true,
+                    'languageId' => 0,
+                    'base' => '/',
+                    'locale' => 'en_US.UTF-8',
+                    'navigationTitle' => 'English',
+                    'flag' => 'us',
+                ],
+            ],
+        ]);
+        $this->get(CacheManager::class)->flushCaches();
+
+        $this->setUpFrontendRootPage(1, [
+            'EXT:bootstrap_package/Tests/Functional/Service/Fixtures/ContentElementVariants/setup.typoscript',
+        ]);
+    }
+
+    /**
+     * Column 0 of "2_columns" carries multiplier 0.75 and gutter 40 for
+     * default, xlarge and large, so 1280 becomes (1280 - 40) * 0.75. The
+     * tiers the column does not configure keep the width they started with.
+     */
+    #[Test]
+    public function narrowsByTheColumnOfTheBackendLayoutThePageCarries(): void
+    {
+        self::assertStringContainsString(
+            '[1:default=930,xlarge=795,large=660,medium=680,small=500,extrasmall=374]',
+            $this->render(1)
+        );
+    }
+
+    /**
+     * A page without a backend layout resolves to "default", where column 0
+     * is not configured — nothing narrows, and the base variants stand.
+     */
+    #[Test]
+    public function leavesTheVariantsAloneForAnUnconfiguredColumn(): void
+    {
+        self::assertStringContainsString(
+            '[2:default=1280,xlarge=1100,large=920,medium=680,small=500,extrasmall=374]',
+            $this->render(2)
+        );
+    }
+
+    /**
+     * The same page, in a footer column that "default" does configure. This
+     * is what ifEmpty = default on the backendlayout TypoScript object buys:
+     * without it an empty pagelayout would reach no configuration at all and
+     * this element would keep the full width.
+     */
+    #[Test]
+    public function resolvesAnEmptyPageLayoutToTheDefaultBackendLayout(): void
+    {
+        self::assertStringContainsString(
+            '[3:default=400,xlarge=340,large=280,medium=200,small=500,extrasmall=374]',
+            $this->render(2)
+        );
+    }
+
+    private function render(int $pageId): string
+    {
+        $response = $this->executeFrontendSubRequest(
+            new InternalRequest('http://localhost/index.php?id=' . $pageId)
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        return (string)$response->getBody();
+    }
+}

--- a/Tests/Functional/Service/Fixtures/ContentElementVariants/VariantWidths.php
+++ b/Tests/Functional/Service/Fixtures/ContentElementVariants/VariantWidths.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Functional\Service\Fixtures\ContentElementVariants;
+
+use BK2K\BootstrapPackage\DataProcessing\ContainerContextProcessor;
+use BK2K\BootstrapPackage\Service\ContentElementVariantsService;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
+use TYPO3\CMS\Core\TypoScript\TypoScriptService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+/**
+ * Stands in for a plugin asking the service what its box is.
+ *
+ * A userFunc receives the request carrying currentContentObject, which is
+ * the channel an Extbase controller reads the same object from.
+ */
+final class VariantWidths
+{
+    #[AsAllowedCallable]
+    public function render(string $content, array $conf, ServerRequestInterface $request): string
+    {
+        $contentObject = $request->getAttribute('currentContentObject');
+        if (!$contentObject instanceof ContentObjectRenderer) {
+            return '[no content object]';
+        }
+
+        $settings = GeneralUtility::makeInstance(TypoScriptService::class)
+            ->convertTypoScriptArrayToPlainArray($conf['settings.'] ?? []);
+
+        $service = new ContentElementVariantsService(
+            GeneralUtility::makeInstance(ContainerContextProcessor::class)
+        );
+
+        $widths = [];
+        foreach ($service->getVariants($settings, $contentObject) as $name => $variant) {
+            $widths[] = $name . '=' . $variant['width'];
+        }
+
+        return '[' . $contentObject->data['uid'] . ':' . implode(',', $widths) . ']';
+    }
+}

--- a/Tests/Functional/Service/Fixtures/ContentElementVariants/pages.csv
+++ b/Tests/Functional/Service/Fixtures/ContentElementVariants/pages.csv
@@ -1,0 +1,4 @@
+"pages",,,,,,,
+,"uid","pid","sorting","doktype","slug","title","backend_layout","backend_layout_next_level"
+,1,0,256,1,"/","Two columns","pagets__2_columns",""
+,2,1,256,1,"/no-layout","No layout","",""

--- a/Tests/Functional/Service/Fixtures/ContentElementVariants/setup.typoscript
+++ b/Tests/Functional/Service/Fixtures/ContentElementVariants/setup.typoscript
@@ -1,0 +1,23 @@
+@import 'EXT:bootstrap_package/Configuration/Sets/ContentElements/TypoScript/Helper/ContentElement.typoscript'
+
+config {
+    disableAllHeaderCode = 1
+    debug = 0
+}
+
+page = PAGE
+page {
+    typeNum = 0
+    10 = CONTENT
+    10 {
+        table = tt_content
+        select {
+            orderBy = sorting
+        }
+        renderObj = USER
+        renderObj {
+            userFunc = BK2K\BootstrapPackage\Tests\Functional\Service\Fixtures\ContentElementVariants\VariantWidths->render
+            settings < lib.contentElement.settings.responsiveimages
+        }
+    }
+}

--- a/Tests/Functional/Service/Fixtures/ContentElementVariants/tt_content.csv
+++ b/Tests/Functional/Service/Fixtures/ContentElementVariants/tt_content.csv
@@ -1,0 +1,5 @@
+"tt_content",,,,,
+,"uid","pid","sorting","CType","colPos","header"
+,1,1,256,"text",0,"in the main column of a two column layout"
+,2,2,256,"text",0,"in the main column without a layout"
+,3,2,512,"text",10,"in a footer column without a layout"

--- a/Tests/Unit/Service/ContentElementVariantsServiceTest.php
+++ b/Tests/Unit/Service/ContentElementVariantsServiceTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+/*
+ * This file is part of the package bk2k/bootstrap-package.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+namespace BK2K\BootstrapPackage\Tests\Unit\Service;
+
+use BK2K\BootstrapPackage\DataProcessing\ContainerContextProcessor;
+use BK2K\BootstrapPackage\Service\ContentElementVariantsService;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * Testcase for class \BK2K\BootstrapPackage\Service\ContentElementVariantsService
+ */
+class ContentElementVariantsServiceTest extends UnitTestCase
+{
+    /**
+     * One variant, so the arithmetic stays readable: gutters come off before
+     * the multiplier is applied, corrections after it.
+     */
+    private const SETTINGS = [
+        'variants' => [
+            'default' => [
+                'breakpoint' => 1400,
+                'width' => 1200,
+            ],
+        ],
+        'backendlayout' => [
+            'default' => [
+                '0' => [
+                    'multiplier' => ['default' => 0.5],
+                    'gutters' => ['default' => 40],
+                ],
+            ],
+            '2_columns' => [
+                '0' => [
+                    'multiplier' => ['default' => 0.25],
+                ],
+            ],
+        ],
+    ];
+
+    private function subject(): ContentElementVariantsService
+    {
+        return new ContentElementVariantsService(self::createStub(ContainerContextProcessor::class));
+    }
+
+    private function contentObject(string $pagelayout, int $colPos = 0): ContentObjectRenderer
+    {
+        $contentObject = self::createStub(ContentObjectRenderer::class);
+        $contentObject->method('getData')->willReturn($pagelayout);
+        $contentObject->data = ['colPos' => $colPos];
+
+        return $contentObject;
+    }
+
+    public function testNarrowWithoutConfigurationReturnsVariantsUnchanged(): void
+    {
+        $variants = ['default' => ['breakpoint' => 1400, 'width' => 1200]];
+
+        self::assertSame($variants, $this->subject()->narrow($variants, null));
+    }
+
+    public function testNarrowRemovesGuttersBeforeApplyingTheMultiplier(): void
+    {
+        $variants = ['default' => ['breakpoint' => 1400, 'width' => 1200]];
+        $result = $this->subject()->narrow($variants, [
+            'multiplier' => ['default' => 0.5],
+            'gutters' => ['default' => 40],
+        ]);
+
+        self::assertSame(580, $result['default']['width']);
+    }
+
+    public function testGetVariantsNarrowsByTheBackendLayoutColumn(): void
+    {
+        $result = $this->subject()->getVariants(self::SETTINGS, $this->contentObject('2_columns'));
+
+        self::assertSame(300, $result['default']['width']);
+    }
+
+    public function testGetVariantsStripsThePagetsPrefix(): void
+    {
+        $result = $this->subject()->getVariants(self::SETTINGS, $this->contentObject('pagets__2_columns'));
+
+        self::assertSame(300, $result['default']['width']);
+    }
+
+    /**
+     * The backendlayout TypoScript object carries ifEmpty = default, so a page
+     * without a layout has to reach the same configuration here.
+     */
+    public function testGetVariantsFallsBackToTheDefaultBackendLayout(): void
+    {
+        $result = $this->subject()->getVariants(self::SETTINGS, $this->contentObject(''));
+
+        self::assertSame(580, $result['default']['width']);
+    }
+
+    public function testGetVariantsLeavesVariantsUntouchedForAnUnconfiguredColumn(): void
+    {
+        $result = $this->subject()->getVariants(self::SETTINGS, $this->contentObject('2_columns', 2));
+
+        self::assertSame(1200, $result['default']['width']);
+    }
+}


### PR DESCRIPTION
## Description

The content element layout narrows the image variants down to the box an
element renders in, first by its backend layout column, then by every container
around it. An Extbase plugin registered as a content element is rendered
through `Generic.html`, which hands off to `tt_content.<CType>.20` via
`f:cObject`. That call carries `data` and `table` and nothing else, so the
variants the layout calculated never reach the plugin's rendering context, and
an image rendered there falls back to whatever width its template hard codes.

`ContentElementVariantsService` answers the same question in PHP. It reads the
same settings, uses the same `ImageVariantsUtility`, and reproduces the
`ifEmpty = default` of the `backendlayout` object, so a plugin arrives at the
widths the layout would have handed it. `narrow()` is public for the steps an
element applies on top of its box, such as a grid column count.

`Default.html` is deliberately left as it is. Switching it over would mean the
layout and the service share one implementation, which is the better end state
— but it touches every content element this package renders, so it belongs in a
change of its own. Happy to do it here instead if you prefer.

## Type of change

* [ ] Bugfix
* [ ] Task
* [x] Feature
* [ ] Documentation

## Related issues

None — I did not find an existing issue for this.

## How to validate

1. `composer test:php:unit` — six cases on the arithmetic and the layout lookup.
2. `composer test:php:functional` — three cases through a real frontend request,
   against the settings this package ships. `Tests/Functional/Service/Fixtures/`
   carries a `userFunc` standing in for a plugin: it receives
   `currentContentObject` on the request, which is the channel an Extbase
   controller reads the same object from.
3. The widths asserted there are the ones the layout arrives at for the same
   element, e.g. column 0 of `2_columns` is `(1280 - 40) * 0.75 = 930`, and a
   page without a layout reaches the `default` block through `ifEmpty`.
4. Docs render clean with `ghcr.io/typo3-documentation/render-guides`; the new
   section is under *Configuration → Image Rendering → Resolving Variants in
   PHP*.

## AI assistance

* Agent and version: Claude Code
* Model and effort/reasoning level: Claude Opus 5, extended thinking
* Share written by the agent: all of it — code, tests, fixtures and
  documentation. I directed the work, decided the scope and made the calls the
  agent surfaced, but I did not write the lines.
* Reviewed and understood before pushing: yes

## Checklist

* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [ ] `composer phpstan` passes — see note below
* [x] `composer test` passes
* [x] A bugfix comes with a test — not a bugfix; unit and functional tests included
* [x] Holds on every TYPO3 and PHP version declared in `composer.json` — see note below
* [x] Assets rebuilt and committed if SCSS, JavaScript or icons changed — none touched
* [x] Documentation updated if the change is user facing

### Notes on the unchecked boxes

**PHPStan**: `master` carries one finding independent of this branch, which
only PHPStan 2.2.12 (released 31 Aug) reports:
Classes/Utility/TypoScriptUtility.php:65
Strict comparison using !== between string and null will always evaluate to true.

`composer.lock` is not committed, so every run resolves the newest matching
version — the last push build on `master`, on 28 Aug, still had an older one
and was green. Nothing in this branch adds a finding. Sent as a one-liner in
#1656, which is green on all eight cells.

**Version coverage**: verified locally on TYPO3 13.4.34 and 14.3.6, both on
PHP 8.5.7 — two of the eight matrix cells. Same result on both: no new PHPStan
finding, no new CGL finding, all unit and functional tests pass. The four
functional tests skipped on 13.4 are pre-existing version-gated ones and none
of the tests added here. The remaining PHP versions are CI's answer, not mine.
The one version-sensitive thing I checked by hand is `#[AsAllowedCallable]` on
the test fixture, which the frontend now requires for `userFunc` callbacks: it
exists on both 13.4 and 14.3.