### PR TITLE
[TASK] Drop the dead null check in TypoScriptUtility

### DIFF
--- a/Classes/Utility/TypoScriptUtility.php
+++ b/Classes/Utility/TypoScriptUtility.php
@@ -61,10 +61,7 @@ class TypoScriptUtility
                     $nested = [];
                 }
             }
-            $lastPart = array_shift($parts);
-            if ($lastPart !== null) {
-                $nested[$lastPart] = $value;
-            }
+            $nested[array_shift($parts)] = $value;
         }
         return $output;
     }


### PR DESCRIPTION
## Description

Backport of #1656 to `BP_16_0`.

CI resolves PHPStan 2.2.13 now, which reads that `array_shift()` cannot
return `null` after the loop in `TypoScriptUtility::unflatten()` and
fails every matrix cell on the guard that follows. `master` dropped the
guard in #1656; this branch never received it, so every pull request
against `BP_16_0` is red on PHPStan — #1658 first. No behaviour changes.

## Type of change

* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## Related issues

Unblocks #1658.

## How to validate

1. `composer phpstan` on `BP_16_0` fails in `Classes/Utility/TypoScriptUtility.php:65` with PHPStan 2.2.13.
2. With this change it passes; the file is byte-identical to `master`.

## AI assistance

* Agent and version: Claude Code, VS Code extension
* Model and effort/reasoning level: Claude Fable 5.1, session default
* Share written by the agent: none of the code — the commit is the
  unchanged cherry-pick of #1656 by Alexander Hahn. The agent diagnosed
  the red run of #1658, picked the commit and wrote this description.
* Reviewed and understood before pushing: yes, diagnosis and commit
  reviewed by the maintainer

## Checklist

* [ ] Targets `master` — backport, `master` has it since #1656
* [x] Commits are signed off (`git commit -s`) — appreciated, not
      required
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes — run with PHPStan 2.2.13 on the
      identical file
* [x] `composer test` passes
* [ ] A bugfix comes with a test that fails without it — not a bugfix
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
* [ ] Assets rebuilt and committed if SCSS, JavaScript or icons changed — none changed
* [ ] Documentation updated if the change is user facing — not user facing
