### PR TITLE
[TASK] Make the FrameClassUpdate test run on SQLite

### DIFF
--- a/Tests/Functional/Updates/FrameClassUpdateTest.php
+++ b/Tests/Functional/Updates/FrameClassUpdateTest.php
@@ -44,7 +44,7 @@ final class FrameClassUpdateTest extends FunctionalTestCase
     public function updateTest(): void
     {
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
-        $connection->executeQuery('ALTER TABLE tt_content ADD section_frame int(11) unsigned DEFAULT "0" NOT NULL;');
+        $connection->executeQuery('ALTER TABLE tt_content ADD section_frame int DEFAULT 0 NOT NULL;');
 
         $subject = new FrameClassUpdate();
         $this->importCSVDataSet(__DIR__ . '/Fixtures/FrameClassUpdate/Input.csv');


### PR DESCRIPTION
## Description

Backport of #1661 to `BP_16_0`. Merge it after #1661 is in.

The functional test for `FrameClassUpdate` recreates the dropped
`section_frame` column with raw MySQL syntax. `int(11) unsigned` is a
syntax error on SQLite, so the whole functional suite dies there.
Written as portable SQL the test runs on every platform the testing
framework supports.

## Type of change

* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## Related issues

None.

## How to validate

1. `ddev composer test:php:functional` — green, as before.
2. `ddev exec bash -c 'typo3DatabaseDriver=pdo_sqlite .build/bin/phpunit -c Build/phpunit-functional.xml'`
   — green. Without the change the same command fails with
   `SQLSTATE[HY000]: General error: 1 near "unsigned": syntax error`.

Both runs were done on the `master` branch for #1661; the test file is
byte identical on `BP_16_0` and the CI matrix is the same, so the run
was not repeated here.

## AI assistance

* Agent and version: Claude Code, VS Code extension
* Model and effort/reasoning level: Claude Opus 5 (1M context), default
  effort
* Share written by the agent: the whole change and this description
* Reviewed and understood before pushing: not yet — opened on request,
  review pending

## Checklist

* [ ] Targets `master` — no, this is the backport; `master` is #1661
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged
* [x] `composer phpstan` passes
* [x] `composer test` passes
* [ ] A bugfix comes with a test that fails without it — not
      applicable, the change is the test
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
      — plain SQL, no version specific API
* [ ] Assets rebuilt — not applicable
* [ ] Documentation updated — not applicable, not user facing
