### PR TITLE
[TASK] Run the functional tests on SQLite

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -16,10 +16,6 @@ composer_version: "2"
 web_environment:
     - PATH=/var/www/html/.build/bin:$PATH
     - TYPO3_CONTEXT=Development
-    - typo3DatabaseHost=db
-    - typo3DatabaseName=t3func
-    - typo3DatabasePassword=root
-    - typo3DatabaseUsername=root
 nodejs_version: "24"
 corepack_enable: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,6 @@ jobs:
       matrix:
         typo3: ['^13.4', '^14.3']
         php: ['8.2', '8.3', '8.4', '8.5']
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
     steps:
       - id: checkout
         name: Checkout Code
@@ -87,10 +75,6 @@ jobs:
           composer test:php:functional
         env:
           COMPOSER_PROCESS_TIMEOUT: 1200
-          typo3DatabaseHost: 127.0.0.1
-          typo3DatabaseName: t3func
-          typo3DatabasePassword: root
-          typo3DatabaseUsername: root
 
   build-frontend:
     name: Build Frontend

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,13 @@
 
 ## Commands
 
-* `ddev start` · `ddev launch typo3` · `ddev composer …` (provides the
-  DB for functional tests)
-* `composer test` — lint + unit + functional; functional needs the DB →
+* `ddev start` · `ddev launch typo3` · `ddev composer …`
+* `composer test` — lint + unit + functional; the functional tests run
+  on SQLite and need no database server, only `pdo_sqlite` in PHP →
   `ddev composer test:php:functional`
+* Running them against MySQL instead means setting `typo3DatabaseDriver`
+  and the four `typo3Database*` connection variables yourself — nothing
+  in the repository sets them
 * `composer cgl:ci` (check) · `composer cgl` (rewrites)
 * `composer phpstan` — `Build/phpstan.neon`
 * `composer changelog` · `composer set-version`

--- a/Build/phpunit-functional.xml
+++ b/Build/phpunit-functional.xml
@@ -12,6 +12,9 @@
   beStrictAboutTestsThatDoNotTestAnything="false"
   cacheDirectory=".phpunit.cache"
   requireCoverageMetadata="false">
+  <php>
+    <env name="typo3DatabaseDriver" value="pdo_sqlite"/>
+  </php>
   <testsuites>
     <testsuite name="bk2k-bootstrap-package-functional-tests">
       <directory>../Tests/Functional</directory>


### PR DESCRIPTION
## Description

The functional tests run on SQLite. The `mysql:8.0` service is gone
from the CI and the `typo3Database*` variables are gone from the DDEV
container.

The driver is declared in `Build/phpunit-functional.xml`, not in the CI
job, so a local checkout and the CI run the suite the same way and
neither carries database settings.

The service was started in all eight matrix jobs while only the two
`8.5` ones actually run the functional tests — every other job paid for
a database it never touched. SQLite needs no service at all.

Nothing but the testing framework ever read the four `typo3Database*`
variables: the development instance takes its connection from the DDEV
generated `config/system/additional.php`, which points at `db`/`db`,
not at the `t3func`/`root` those variables described. Running the suite
against MySQL is still possible, it just means setting
`typo3DatabaseDriver` and the connection variables yourself; `AGENTS.md`
says so.

It is also faster. Measured locally on the full suite (72 tests, PHP
8.5, MySQL 8.0 in a neighbouring container):

| Driver       | Time  |
| ------------ | ----- |
| MySQL 8.0    | 154 s |
| `pdo_sqlite` | 92 s  |

Same 72 tests, same 378 assertions on both. The gain is setup, not
queries: with SQLite the testing framework builds the schema once per
test case and copies the empty database file for every following test
instead of truncating tables. In the CI the functional jobs went from
5m12s and 6m05s to 3m32s and 4m25s, and the six jobs that run no
functional tests from around a minute to half of that.

The trade off is that the CI no longer exercises MySQL. The package
reaches the database through TCA, QueryBuilder and DataHandler; after
#1661 there is no hand written SQL left in the tests.

## Type of change

* [ ] Bugfix
* [x] Task
* [ ] Feature
* [ ] Documentation

## Related issues

Builds on #1661, which removed the last MySQL specific SQL from the
test suite.

## How to validate

1. The CI run on this pull request — the functional jobs are green
   without a database service.
2. Nothing reaches MySQL any more, with the DDEV database deliberately
   out of reach:
   `ddev exec bash -c 'typo3DatabaseHost=doesnotexist .build/bin/phpunit -c Build/phpunit-functional.xml'`
   — 72 tests, 378 assertions, green.
3. And with the variables gone rather than wrong:
   `ddev exec bash -c 'unset typo3DatabaseHost typo3DatabaseName typo3DatabaseUsername typo3DatabasePassword; .build/bin/phpunit -c Build/phpunit-functional.xml'`
   — same result.
4. The override still works: run 2 with `typo3DatabaseDriver=mysqli`
   prepended fails on the unreachable host.

A `ddev restart` is needed for the container to drop the variables.

## AI assistance

* Agent and version: Claude Code, VS Code extension
* Model and effort/reasoning level: Claude Opus 5 (1M context), default
  effort
* Share written by the agent: the whole change and this description
* Reviewed and understood before pushing: not yet — opened on request,
  review pending

## Checklist

* [x] Targets `master`
* [x] Commits are signed off (`git commit -s`)
* [x] Commit subjects follow `[BUGFIX|TASK|FEATURE] Subject`
* [x] `composer cgl` leaves the code unchanged — no PHP touched
* [x] `composer phpstan` passes — no PHP touched
* [x] `composer test` passes
* [ ] A bugfix comes with a test that fails without it — not
      applicable
* [x] Holds on every TYPO3 and PHP version declared in `composer.json`
      — the CI matrix itself is unchanged
* [ ] Assets rebuilt — not applicable
* [x] Documentation updated — `AGENTS.md`; `Documentation/` says
      nothing about the test database
